### PR TITLE
ISSUE 367 (The Sieve) + ISSUE 368 (The Model Picks Up the Pen)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # CLAUDE.md — K:BOT Project
 
+> **Publishing a new kernel.chat issue?** Read
+> [`src/content/issues/PUBLISHING.md`](src/content/issues/PUBLISHING.md)
+> first. It is the single source of truth for the magazine workflow —
+> identity decisions, spread types, deploy steps, collision handling.
+
 ## I. SYSTEM ROLE
 
 You are the engineering engine for **K:BOT** — an open-source terminal AI agent by kernel.chat group. K:BOT is the primary product. The web companion (kernel.chat) lives in `src/` and `supabase/`.

--- a/src/components/DispatchFeature.css
+++ b/src/components/DispatchFeature.css
@@ -1,0 +1,670 @@
+/* ──────────────────────────────────────────────────────────────
+   DispatchFeature — wire-style news dispatch
+   Grammar: Courier slug marquee at the top, editorial bridge
+   line, newspaper dateline, gummed dossier sample-card, hollow-
+   square checkbox numbering, mid-spread BULLETIN pull-quote.
+   All of it is dispatch-identity — nothing here should be
+   reusable outside this spread type.
+   ────────────────────────────────────────────────────────────── */
+
+.pop-dispatch {
+  padding: 0 0 96px;
+  border-top: 1px solid var(--pop-hairline-soft);
+  border-bottom: 1px solid var(--pop-hairline-soft);
+  position: relative;
+}
+
+.pop-dispatch-inner {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 48px 48px 0;
+  position: relative;
+}
+
+.pop-dispatch.pop-stock-ink {
+  border-top-color: rgba(250, 249, 246, 0.15);
+  border-bottom-color: rgba(250, 249, 246, 0.15);
+}
+
+/* ── Wire slug band ─────────────────────────────────────── */
+/* Courier mono marquee pinned to the top of the dispatch. Two
+   tomato hairlines sandwich it — reads as wire-ticker tape.
+   Drift respects prefers-reduced-motion via the global override. */
+.pop-dispatch-slug {
+  overflow: hidden;
+  border-top: 1px solid var(--pop-tomato);
+  border-bottom: 1px solid var(--pop-tomato);
+  background: var(--pop-tomato-soft);
+  padding: 8px 0;
+}
+
+.pop-dispatch-slug-track {
+  display: inline-flex;
+  align-items: center;
+  gap: 2.5ch;
+  white-space: nowrap;
+  animation: pop-dispatch-slug-drift 48s linear infinite;
+  will-change: transform;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+}
+
+.pop-dispatch-slug-text {
+  flex: 0 0 auto;
+}
+
+.pop-dispatch-slug-dot {
+  flex: 0 0 auto;
+  font-size: 8px;
+  line-height: 1;
+  color: var(--pop-tomato);
+  opacity: 0.9;
+}
+
+@keyframes pop-dispatch-slug-drift {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(calc(-100% / 3)); }
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+.pop-dispatch-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+
+.pop-dispatch-bridge {
+  font-family: var(--font-serif);
+  font-size: clamp(14px, 1.2vw, 16px);
+  line-height: 1.4;
+  color: var(--pop-coffee);
+  max-width: 52ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.pop-dispatch-bridge em {
+  font-style: italic;
+}
+
+.pop-dispatch-bridge-ref {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+  font-style: normal;
+  margin-right: 4px;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-bridge {
+  color: var(--pop-sepia);
+}
+
+.pop-dispatch-title {
+  font-size: clamp(44px, 7vw, 96px);
+  line-height: 0.92;
+  margin: 8px 0 0;
+  letter-spacing: -0.035em;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-title { color: var(--pop-ivory); }
+
+.pop-dispatch-title-jp { margin: 0; }
+.pop-dispatch.pop-stock-ink .pop-dispatch-title-jp { color: var(--pop-sepia); }
+
+.pop-dispatch-deck {
+  font-size: clamp(18px, 2.2vw, 24px);
+  max-width: 52ch;
+  margin: 8px 0 0;
+  line-height: 1.35;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-deck { color: var(--pop-sepia); }
+
+.pop-dispatch-dateline {
+  margin: 10px 0 0;
+  color: var(--pop-ink);
+  opacity: 0.8;
+  letter-spacing: 0.1em;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-dateline { color: var(--pop-sepia); }
+
+.pop-dispatch-byline {
+  margin: 4px 0 0;
+  color: var(--pop-coffee);
+  opacity: 0.85;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-byline { color: var(--pop-sepia); }
+
+.pop-dispatch-rule {
+  margin: 24px auto;
+  max-width: 120px;
+  height: 1px;
+  background: var(--pop-hairline);
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-rule {
+  background: rgba(250, 249, 246, 0.25);
+}
+
+.pop-dispatch-divider {
+  margin: 32px 0 48px;
+}
+
+/* ── Dossier card ───────────────────────────────────────── */
+/* A gummed-paper sample tag inset into the spread. Rotated ~3°
+   so it reads as stuck-on, not UI chrome. Sits below the header
+   and above the intro. Stencil-mono labels, serif values. */
+.pop-dispatch-dossier {
+  position: relative;
+  max-width: 560px;
+  margin: 0 auto 40px;
+  padding: 28px 28px 24px;
+  background: var(--pop-cream, var(--pop-ivory));
+  color: var(--pop-ink);
+  border: 1px solid var(--pop-hairline);
+  box-shadow:
+    2px 3px 0 rgba(31, 30, 29, 0.05),
+    6px 8px 16px rgba(31, 30, 29, 0.08);
+  transform: rotate(-1.2deg);
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-dossier {
+  background: var(--pop-ivory);
+  color: var(--pop-ink);
+  box-shadow:
+    2px 3px 0 rgba(0, 0, 0, 0.2),
+    6px 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.pop-dispatch-dossier-stamp {
+  position: absolute;
+  top: -14px;
+  right: 20px;
+  transform: rotate(6deg);
+  padding: 4px 12px;
+  border: 1.5px solid var(--pop-tomato);
+  background: var(--pop-ivory);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: 1px 1px 0 var(--pop-tomato-soft);
+}
+
+.pop-dispatch-dossier-stamp-label {
+  font-size: 9px;
+  color: var(--pop-coffee);
+}
+
+.pop-dispatch-dossier-stamp strong {
+  font-size: 13px;
+  color: var(--pop-tomato);
+  font-weight: 700;
+}
+
+.pop-dispatch-dossier-fields {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin: 0 0 20px;
+  padding: 0 0 16px;
+  border-bottom: 1px dashed var(--pop-hairline-soft);
+}
+
+.pop-dispatch-dossier-fields > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.pop-dispatch-dossier-fields dt {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+}
+
+.pop-dispatch-dossier-fields dd {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.3;
+  margin: 0;
+  color: var(--pop-ink);
+  text-wrap: balance;
+}
+
+/* ── Partner roll ───────────────────────────────────────── */
+.pop-dispatch-partners {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.pop-dispatch-partners-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+}
+
+.pop-dispatch-partners ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+}
+
+.pop-dispatch-partners li {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 12px;
+  align-items: baseline;
+  padding: 6px 0;
+  border-bottom: 1px dotted var(--pop-hairline-soft);
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.pop-dispatch-partners li:last-child { border-bottom: 0; }
+
+.pop-dispatch-partners li strong {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+}
+
+.pop-dispatch-partners li span {
+  color: var(--pop-ink);
+  opacity: 0.9;
+  text-wrap: pretty;
+}
+
+/* ── Intro ──────────────────────────────────────────────── */
+.pop-dispatch-intro {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: clamp(18px, 1.5vw, 22px);
+  line-height: 1.55;
+  color: var(--pop-coffee);
+  margin: 0 auto;
+  max-width: 54ch;
+  text-align: center;
+  text-wrap: pretty;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-intro { color: var(--pop-sepia); }
+
+/* ── Proposition list ──────────────────────────────────── */
+.pop-dispatch-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.pop-dispatch-list + .pop-dispatch-list { margin-top: 56px; }
+
+.pop-dispatch-item {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+}
+
+/* ── Left-rail timestamp ────────────────────────────────── */
+/* Thin Courier timestamp sitting in the margin to the left of
+   the item. Visible at >=860px only — below that, the rail
+   would crowd the content column and is hidden. */
+.pop-dispatch-item-time {
+  display: none;
+  position: absolute;
+  top: 6px;
+  left: -92px;
+  width: 80px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.14em;
+  color: var(--pop-coffee);
+  opacity: 0.78;
+  text-transform: uppercase;
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.pop-dispatch-item-time-dot {
+  display: inline-block;
+  margin-right: 4px;
+  color: var(--pop-tomato);
+  font-size: 7px;
+  vertical-align: 1px;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-item-time {
+  color: var(--pop-sepia);
+}
+
+@media (min-width: 860px) {
+  .pop-dispatch-item-time { display: block; }
+}
+
+/* ── Proposition overline ───────────────────────────────── */
+/* Courier tag above each title pulling the contents TAG into
+   the body, e.g. "FIELD · 01". Ties the back-of-book catalog
+   to the prose. */
+.pop-dispatch-item-overline {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+  font-weight: 700;
+  margin-bottom: 2px;
+  display: inline-block;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-item-overline {
+  color: var(--pop-tomato);
+}
+
+.pop-dispatch-item-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 22px;
+  align-items: start;
+}
+
+/* ── Checkbox numbering ─────────────────────────────────── */
+/* Hollow tomato square with a hand-stroked check inside, and the
+   proposition number in Courier below — "verified, filed" rather
+   than "declared". Replaces ForecastFeature's tomato ring. */
+.pop-dispatch-check {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  width: 52px;
+  color: var(--pop-tomato);
+  flex: 0 0 auto;
+  margin-top: 4px;
+}
+
+.pop-dispatch-check-svg {
+  width: 44px;
+  height: 44px;
+  display: block;
+}
+
+.pop-dispatch-check-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--pop-coffee);
+  font-variant-numeric: tabular-nums;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-check-num { color: var(--pop-sepia); }
+
+.pop-dispatch-item-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.pop-dispatch-item-title {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: clamp(24px, 3vw, 34px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--pop-ink);
+  text-wrap: balance;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-item-title { color: var(--pop-ivory); }
+
+.pop-dispatch-item-title-jp {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--pop-coffee);
+  margin: 0;
+  opacity: 0.9;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-item-title-jp { color: var(--pop-sepia); }
+
+.pop-dispatch-item-body {
+  font-family: var(--font-serif);
+  font-size: clamp(17px, 1.3vw, 19px);
+  line-height: 1.65;
+  color: var(--pop-ink);
+  padding-left: 74px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-item-body {
+  color: var(--pop-ivory);
+  opacity: 0.92;
+}
+
+.pop-dispatch-item-para {
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* ── Bulletin pull-quote ────────────────────────────────── */
+/* Mid-spread billboard lifted out of a proposition. Em-dash
+   open / close, mono label above. Breaks the column width so it
+   feels like a pulled-aside press bulletin. */
+.pop-dispatch-bulletin {
+  margin: 72px auto;
+  max-width: 680px;
+  padding: 40px 32px 32px;
+  text-align: center;
+  position: relative;
+  border-top: 2px solid var(--pop-tomato);
+  border-bottom: 2px solid var(--pop-tomato);
+  background:
+    linear-gradient(to bottom, var(--pop-tomato-soft) 0%, transparent 100%);
+}
+
+.pop-dispatch-bulletin-label {
+  display: inline-block;
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 2px 14px;
+  background: var(--pop-ivory);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--pop-tomato);
+  font-weight: 700;
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-bulletin-label {
+  background: var(--pop-ink);
+}
+
+.pop-dispatch-bulletin-text {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: clamp(22px, 3.2vw, 34px);
+  line-height: 1.25;
+  color: var(--pop-ink);
+  margin: 0;
+  padding: 0;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-bulletin-text { color: var(--pop-ivory); }
+
+.pop-dispatch-bulletin-dash {
+  color: var(--pop-tomato);
+  font-style: normal;
+  font-weight: 700;
+  margin: 0 4px;
+}
+
+.pop-dispatch-bulletin-attrib {
+  display: block;
+  margin-top: 14px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-bulletin-attrib {
+  color: var(--pop-sepia);
+}
+
+/* ── Outro ──────────────────────────────────────────────── */
+.pop-dispatch-outro {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: clamp(18px, 1.6vw, 22px);
+  line-height: 1.5;
+  color: var(--pop-coffee);
+  margin: 0 auto;
+  max-width: 54ch;
+  text-align: center;
+  text-wrap: pretty;
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-outro { color: var(--pop-sepia); }
+
+/* ── Sign-off ──────────────────────────────────────────── */
+.pop-dispatch-signoff {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 16px;
+  padding-top: 48px;
+  margin-top: 48px;
+}
+
+.pop-dispatch-signoff-text {
+  font-size: clamp(17px, 1.8vw, 22px);
+  margin: 0;
+  color: var(--pop-coffee);
+}
+.pop-dispatch.pop-stock-ink .pop-dispatch-signoff-text { color: var(--pop-sepia); }
+
+.pop-dispatch-monument { margin-top: 8px; align-items: center; text-align: center; }
+.pop-dispatch.pop-stock-ink .pop-dispatch-monument { color: var(--pop-ivory); }
+.pop-dispatch.pop-stock-ink .pop-dispatch-monument span { color: var(--pop-sepia); }
+.pop-dispatch.pop-stock-ink .pop-dispatch-monument strong { color: var(--pop-tomato); }
+
+/* ── Wire terminator ────────────────────────────────────── */
+/* The "— 30 —" line that closed AP dispatches. Full-width
+   Courier band under the signoff, with a tomato hairline above
+   and below so it reads as tape that just terminated. */
+.pop-dispatch-terminator {
+  margin-top: 48px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--pop-tomato);
+  border-bottom: 1px solid var(--pop-tomato);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.pop-dispatch-terminator-mark {
+  font-size: 14px;
+  letter-spacing: 0.3em;
+  color: var(--pop-tomato);
+  font-weight: 700;
+}
+
+.pop-dispatch-terminator-text {
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+}
+
+.pop-dispatch.pop-stock-ink .pop-dispatch-terminator-text {
+  color: var(--pop-sepia);
+}
+
+/* ── Mobile ─────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .pop-dispatch { padding: 0 0 56px; }
+  .pop-dispatch-inner { padding: 40px 22px 0; }
+  .pop-dispatch-title { font-size: clamp(38px, 11vw, 64px); }
+  .pop-dispatch-deck { font-size: clamp(16px, 4.5vw, 20px); }
+  .pop-dispatch-dateline { font-size: 10px; }
+
+  .pop-dispatch-dossier {
+    padding: 22px 18px 18px;
+    margin: 0 0 32px;
+    transform: rotate(-0.8deg);
+  }
+  .pop-dispatch-dossier-stamp {
+    right: 14px;
+    padding: 3px 10px;
+  }
+  .pop-dispatch-dossier-fields {
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+  }
+  .pop-dispatch-partners li {
+    grid-template-columns: 96px 1fr;
+    gap: 10px;
+    font-size: 13px;
+  }
+
+  .pop-dispatch-list { gap: 40px; }
+  .pop-dispatch-list + .pop-dispatch-list { margin-top: 40px; }
+  .pop-dispatch-divider { margin: 24px 0 32px; }
+  .pop-dispatch-item-head {
+    grid-template-columns: auto 1fr;
+    gap: 14px;
+  }
+  .pop-dispatch-check { width: 44px; }
+  .pop-dispatch-check-svg { width: 36px; height: 36px; }
+  .pop-dispatch-item-title { font-size: clamp(20px, 5.5vw, 26px); }
+  .pop-dispatch-item-body {
+    font-size: 16px;
+    line-height: 1.6;
+    padding-left: 0;
+  }
+
+  .pop-dispatch-bulletin {
+    margin: 48px auto;
+    padding: 32px 20px 24px;
+  }
+  .pop-dispatch-bulletin-text { font-size: clamp(20px, 6vw, 28px); }
+
+  .pop-dispatch-signoff { padding-top: 32px; margin-top: 32px; }
+}

--- a/src/components/DispatchFeature.tsx
+++ b/src/components/DispatchFeature.tsx
@@ -1,0 +1,307 @@
+import type { ReactNode } from 'react'
+import type { IssueRecord, DispatchSpread } from '../content/issues'
+import './DispatchFeature.css'
+
+interface DispatchFeatureProps {
+  spread: DispatchSpread
+  issue: IssueRecord
+}
+
+/**
+ * DispatchFeature — wire-style news dispatch.
+ *
+ * Editorial tool #4 in the IssueFeature family. Where forecast is
+ * general outlook and essay is narrative observation, dispatch is
+ * reactive — the night a specific event happened, written before
+ * the takes industrialised. The grammar is borrowed from the
+ * newswire: repeating slug band, newspaper dateline, dossier card
+ * with FILED / STATUS / partner roll, checkbox-numbered stakes, a
+ * mid-spread bulletin pull-quote, an optional bridge sentence to
+ * the preceding issue so the magazine reads as a running serial.
+ *
+ * Visual grammar — all dispatch-identity, none of it leaks to
+ * other spread types:
+ *   · Courier wire-slug marquee at the top, Esperanto-speed drift
+ *   · dateline as pop-folio micro line under the deck
+ *   · gummed-paper dossier card inset into the spread margin
+ *   · hollow-square + hand-stroked check for each proposition
+ *   · BULLETIN callout sat mid-column between items
+ *   · bridge line ("FROM ISSUE 366 →") above the title
+ */
+export function DispatchFeature({ spread, issue }: DispatchFeatureProps) {
+  const stockClass = `pop-stock-${spread.stock ?? 'ivory'}`
+
+  const splitAt = Math.min(4, spread.propositions.length)
+  const firstHalf = spread.propositions.slice(0, splitAt)
+  const secondHalf = spread.propositions.slice(splitAt)
+
+  return (
+    <section
+      className={`pop-dispatch ${stockClass}`}
+      aria-labelledby="pop-dispatch-title"
+    >
+      {/* ── Wire slug band ─────────────────────────────────
+          A Courier mono marquee announcing the dispatch —
+          wire-ticker energy, drifts at the same speed as the
+          cover's JP marquee so the two feel related but
+          carry different content. Duplicated content + a
+          translate loop keeps the seam invisible. */}
+      <div className="pop-dispatch-slug" aria-label={spread.slug}>
+        <div className="pop-dispatch-slug-track" aria-hidden="true">
+          <SlugRun text={spread.slug} />
+          <SlugRun text={spread.slug} />
+          <SlugRun text={spread.slug} />
+        </div>
+      </div>
+
+      <div className="pop-dispatch-inner">
+
+        {/* ── Header ─────────────────────────────────────── */}
+        <header className="pop-dispatch-header">
+          <span className="pop-kicker pop-kicker--tomato">{spread.kicker}</span>
+
+          {spread.bridge && (
+            <p className="pop-dispatch-bridge">
+              <span className="pop-dispatch-bridge-ref">
+                FROM ISSUE {spread.bridge.issue} →
+              </span>{' '}
+              <em>{spread.bridge.text}</em>
+            </p>
+          )}
+
+          <hr className="pop-rule pop-rule--short pop-rule--tomato" />
+
+          <h2 id="pop-dispatch-title" className="pop-display pop-dispatch-title">
+            {spread.title}
+          </h2>
+
+          <p className="pop-feature-jp pop-dispatch-title-jp">
+            {spread.titleJp}
+          </p>
+
+          <p className="pop-swash pop-dispatch-deck">{spread.deck}</p>
+
+          <p className="pop-folio pop-dispatch-dateline">{spread.dateline}</p>
+
+          <p className="pop-folio pop-dispatch-byline">{spread.byline}</p>
+        </header>
+
+        {/* ── Dossier card ─────────────────────────────────
+            Stencil-mono sample tag with STATUS stamp, FILED,
+            ISSUE, BYLINE, and the partner roll. Rotates ~3°
+            so it reads as a gummed label, not UI chrome. */}
+        <aside className="pop-dispatch-dossier" aria-label="Dispatch dossier">
+          <div className="pop-dispatch-dossier-stamp">
+            <span className="pop-dispatch-dossier-stamp-label">STATUS</span>
+            <strong>{spread.status}</strong>
+          </div>
+
+          <dl className="pop-dispatch-dossier-fields">
+            <div>
+              <dt>FILED</dt>
+              <dd>{spread.filedAt}</dd>
+            </div>
+            <div>
+              <dt>ISSUE</dt>
+              <dd>{issue.number} · {issue.month} {issue.year}</dd>
+            </div>
+            <div>
+              <dt>BYLINE</dt>
+              <dd>THE EDITORS</dd>
+            </div>
+          </dl>
+
+          {spread.partners && spread.partners.length > 0 && (
+            <div className="pop-dispatch-partners">
+              <span className="pop-dispatch-partners-label">
+                PARTNERS · {String(spread.partners.length).padStart(2, '0')}
+              </span>
+              <ul>
+                {spread.partners.map((p) => (
+                  <li key={p.name}>
+                    <strong>{p.name}</strong>
+                    <span>{p.role}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </aside>
+
+        {/* ── Optional intro block ───────────────────────── */}
+        {spread.intro && (
+          <>
+            <hr className="pop-rule pop-dispatch-rule" />
+            <p className="pop-dispatch-intro">{spread.intro}</p>
+          </>
+        )}
+
+        <hr className="pop-rule pop-rule--tomato pop-dispatch-divider" />
+
+        {/* ── Propositions, first half ───────────────────── */}
+        <ol className="pop-dispatch-list">
+          {firstHalf.map((p) => (
+            <DispatchItem key={p.n} p={p} />
+          ))}
+        </ol>
+
+        {/* ── Mid-spread bulletin ────────────────────────── */}
+        {spread.bulletin && (
+          <figure className="pop-dispatch-bulletin" aria-label="Bulletin callout">
+            <span className="pop-dispatch-bulletin-label" aria-hidden="true">
+              — BULLETIN —
+            </span>
+            <blockquote className="pop-dispatch-bulletin-text">
+              <span className="pop-dispatch-bulletin-dash" aria-hidden="true">—</span>
+              {' '}{spread.bulletin.text}{' '}
+              <span className="pop-dispatch-bulletin-dash" aria-hidden="true">—</span>
+            </blockquote>
+            {spread.bulletin.attribution && (
+              <figcaption className="pop-dispatch-bulletin-attrib">
+                {spread.bulletin.attribution}
+              </figcaption>
+            )}
+          </figure>
+        )}
+
+        {/* ── Propositions, second half ──────────────────── */}
+        {secondHalf.length > 0 && (
+          <ol className="pop-dispatch-list" start={splitAt + 1}>
+            {secondHalf.map((p) => (
+              <DispatchItem key={p.n} p={p} />
+            ))}
+          </ol>
+        )}
+
+        {/* ── Optional outro ─────────────────────────────── */}
+        {spread.outro && (
+          <>
+            <hr className="pop-rule pop-dispatch-rule" />
+            <p className="pop-dispatch-outro">{spread.outro}</p>
+          </>
+        )}
+
+        {/* ── Sign-off ──────────────────────────────────── */}
+        <footer className="pop-dispatch-signoff">
+          <hr className="pop-rule pop-rule--short pop-rule--tomato" />
+          <p className="pop-swash pop-dispatch-signoff-text">{spread.signoff}</p>
+          <div className="pop-monument pop-dispatch-monument">
+            <span>ISSUE</span>
+            <strong>{issue.number}</strong>
+            <span>{issue.month} {issue.year}</span>
+          </div>
+        </footer>
+
+      </div>
+
+      {/* ── Wire terminator ─────────────────────────────────
+          The `— 30 —` line that closed old AP dispatches. A
+          single Courier rule flush across the bottom of the
+          section, under the signoff. Full-bleed so it reads
+          as the end of the tape, not just a footer. */}
+      {spread.terminator && (
+        <div className="pop-dispatch-terminator" aria-label="end of dispatch">
+          <span className="pop-dispatch-terminator-mark" aria-hidden="true">— 30 —</span>
+          <span className="pop-dispatch-terminator-text">{spread.terminator}</span>
+        </div>
+      )}
+    </section>
+  )
+}
+
+/** One run of the wire-slug marquee — text then a tomato dot
+ *  separator. Rendered twice in the track so the loop is seamless. */
+function SlugRun({ text }: { text: string }): ReactNode {
+  return (
+    <>
+      <span className="pop-dispatch-slug-text">{text}</span>
+      <span className="pop-dispatch-slug-dot" aria-hidden="true">●</span>
+    </>
+  )
+}
+
+/** A single proposition — checkbox numbering + serif title + body.
+ *  Optional left-rail timestamp and above-title Courier overline
+ *  that pulls the contents tag into the body. */
+function DispatchItem({
+  p,
+}: {
+  p: {
+    n: string
+    title: string
+    titleJp?: string
+    body: string[]
+    overline?: string
+    filedAt?: string
+  }
+}) {
+  return (
+    <li className="pop-dispatch-item">
+      {p.filedAt && (
+        <span
+          className="pop-dispatch-item-time"
+          aria-label={`filed at ${p.filedAt}`}
+        >
+          <span className="pop-dispatch-item-time-dot" aria-hidden="true">●</span>
+          {p.filedAt}
+        </span>
+      )}
+      <div className="pop-dispatch-item-head">
+        <DispatchCheck n={p.n} />
+        <div className="pop-dispatch-item-title-group">
+          {p.overline && (
+            <span className="pop-dispatch-item-overline">
+              {p.overline}{' \u00b7 '}{p.n}
+            </span>
+          )}
+          <h3 className="pop-dispatch-item-title">{p.title}</h3>
+          {p.titleJp && (
+            <p className="pop-dispatch-item-title-jp">{p.titleJp}</p>
+          )}
+        </div>
+      </div>
+      <div className="pop-dispatch-item-body">
+        {p.body.map((para, i) => (
+          <p key={i} className="pop-dispatch-item-para">{para}</p>
+        ))}
+      </div>
+    </li>
+  )
+}
+
+/** Hollow tomato square + hand-stroked check inside, with the
+ *  proposition number printed below in Courier. Reads as a
+ *  clipboard tick — "verified before filing" — not a forecast
+ *  manifesto ring. */
+function DispatchCheck({ n }: { n: string }) {
+  return (
+    <span className="pop-dispatch-check" role="img" aria-label={`item ${n}, verified`}>
+      <svg
+        viewBox="0 0 48 48"
+        className="pop-dispatch-check-svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <rect
+          x="3"
+          y="3"
+          width="42"
+          height="42"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d="M 11 26 Q 15 29 20 34 Q 26 26 38 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span className="pop-dispatch-check-num">{n}</span>
+    </span>
+  )
+}

--- a/src/components/EssayFeature.css
+++ b/src/components/EssayFeature.css
@@ -169,6 +169,330 @@
   text-align: center;
 }
 
+/* ── Dossier (editorial register — opening data card) ──────
+   A fashion-magazine-style front register: numbered catalog of
+   the issue's subject, mono labels paired with serif values,
+   hairline rules between rows. Reads as part of the editorial
+   grammar, not as scientific frontmatter. */
+.pop-essay-dossier {
+  max-width: 640px;
+  margin: 0 auto 56px;
+  padding: 32px 28px;
+  border-top: 2px solid var(--pop-tomato);
+  border-bottom: 1px solid var(--pop-hairline);
+}
+
+.pop-essay-dossier-kicker {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.pop-essay-dossier-note {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--pop-coffee);
+  margin: 4px 0 24px;
+  max-width: 48ch;
+}
+
+.pop-essay-dossier-list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pop-essay-dossier-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 2fr;
+  gap: 24px;
+  padding: 14px 0;
+  border-top: 1px solid var(--pop-hairline-soft);
+  align-items: baseline;
+}
+
+.pop-essay-dossier-row:first-child { border-top: none; padding-top: 4px; }
+.pop-essay-dossier-row:last-child { padding-bottom: 0; }
+
+.pop-essay-dossier-label {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pop-essay-dossier-n {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--pop-tomato);
+  font-weight: 700;
+}
+
+.pop-essay-dossier-label-en {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--letter-spacing-caps);
+  text-transform: uppercase;
+  color: var(--pop-ink);
+  font-weight: 700;
+}
+
+.pop-essay-dossier-label-jp {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--pop-coffee);
+  opacity: 0.8;
+  display: block;
+  width: 100%;
+  margin-top: 2px;
+}
+
+.pop-essay-dossier-value {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pop-essay-dossier-value-en {
+  font-family: var(--font-serif);
+  font-size: 17px;
+  line-height: 1.35;
+  color: var(--pop-ink);
+  text-wrap: balance;
+}
+
+.pop-essay-dossier-value-jp {
+  font-family: var(--font-serif);
+  font-size: 13px;
+  color: var(--pop-coffee);
+  opacity: 0.85;
+}
+
+/* ── Figures (the editorial "by-the-numbers" block) ────────
+   Harper's Index-style grid inserted mid-essay. Oversized tomato
+   numbers anchor the left of each row; serif caption flows right.
+   A hard tomato rule above the block, a hairline below. */
+.pop-essay-data {
+  margin: 48px -8px;
+  padding: 28px 16px 24px;
+  border-top: 2px solid var(--pop-tomato);
+  border-bottom: 1px solid var(--pop-hairline);
+}
+
+.pop-essay-data-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.pop-essay-data-heading {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: clamp(22px, 3vw, 30px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--pop-ink);
+  margin: 4px 0 0;
+}
+
+.pop-essay-data-heading-jp {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--pop-coffee);
+  margin: 0;
+}
+
+.pop-essay-data-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pop-essay-data-stat {
+  display: grid;
+  grid-template-columns: minmax(140px, auto) 1fr;
+  column-gap: 28px;
+  row-gap: 2px;
+  align-items: baseline;
+  padding: 16px 0;
+  border-top: 1px solid var(--pop-hairline-soft);
+}
+
+.pop-essay-data-stat:first-child { border-top: none; }
+
+.pop-essay-data-n {
+  grid-column: 1;
+  grid-row: 1 / span 3;
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-style: italic;
+  font-size: clamp(36px, 5vw, 56px);
+  line-height: 1;
+  color: var(--pop-tomato);
+  letter-spacing: -0.03em;
+  text-align: left;
+}
+
+.pop-essay-data-label {
+  grid-column: 2;
+  font-family: var(--font-serif);
+  font-size: 16px;
+  line-height: 1.4;
+  color: var(--pop-ink);
+  text-wrap: pretty;
+}
+
+.pop-essay-data-label-jp {
+  grid-column: 2;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--pop-coffee);
+  opacity: 0.8;
+}
+
+.pop-essay-data-source {
+  grid-column: 2;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+  opacity: 0.75;
+  margin-top: 4px;
+}
+
+/* ── Further reading (editorial back matter) ───────────────
+   A numbered register of cited sources. Hanging indent, mono
+   metadata, italic titles. Reads as part of the back-of-book
+   grammar — colophon-adjacent, not footnote-adjacent. */
+.pop-essay-refs {
+  max-width: 640px;
+  margin: 56px auto 0;
+  padding: 28px 0 0;
+  border-top: 1px solid var(--pop-hairline);
+}
+
+.pop-essay-refs-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.pop-essay-refs-note {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--pop-coffee);
+  margin: 4px 0 0;
+  max-width: 52ch;
+}
+
+.pop-essay-refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pop-essay-refs-item {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 8px;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--pop-ink);
+  text-indent: 0;
+}
+
+.pop-essay-refs-n {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--pop-tomato);
+  font-weight: 700;
+  padding-top: 2px;
+}
+
+.pop-essay-refs-authors {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+}
+
+.pop-essay-refs-year {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--pop-coffee);
+}
+
+.pop-essay-refs-title {
+  font-style: italic;
+  color: var(--pop-ink);
+}
+
+.pop-essay-refs-journal {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--pop-coffee);
+}
+
+.pop-essay-refs-dot { color: var(--pop-ink); }
+
+/* ── Ink stock — flip prose colors for dark paper ──────────
+   The body prose, byline, JP headings, and signoff default to
+   ink-dark tones that disappear against the ink paper stock.
+   On ink, flip them to ivory/sepia so the essay stays legible. */
+.pop-essay.pop-stock-ink .pop-essay-body { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-byline { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-section-head-jp { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-signoff-text { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-pullquote-attr { color: var(--pop-sepia); }
+
+/* Dossier on ink */
+.pop-essay.pop-stock-ink .pop-essay-dossier-note { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-dossier-label-en { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-dossier-label-jp { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-dossier-value-en { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-dossier-value-jp { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-dossier-row { border-top-color: rgba(250, 249, 246, 0.12); }
+
+/* Figures on ink */
+.pop-essay.pop-stock-ink .pop-essay-data-heading { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-data-heading-jp { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-data-label { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-data-label-jp { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-data-source { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-data-stat { border-top-color: rgba(250, 249, 246, 0.12); }
+
+/* Further reading on ink */
+.pop-essay.pop-stock-ink .pop-essay-refs { border-top-color: rgba(250, 249, 246, 0.18); }
+.pop-essay.pop-stock-ink .pop-essay-refs-note { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-refs-item { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-refs-authors { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-refs-year { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-refs-title { color: var(--pop-ivory); }
+.pop-essay.pop-stock-ink .pop-essay-refs-journal { color: var(--pop-sepia); }
+.pop-essay.pop-stock-ink .pop-essay-refs-dot { color: var(--pop-ivory); }
+
 /* ── Mobile ─────────────────────────────────────────────── */
 @media (max-width: 640px) {
   .pop-essay { padding: 56px 0; }

--- a/src/components/EssayFeature.tsx
+++ b/src/components/EssayFeature.tsx
@@ -36,6 +36,39 @@ export function EssayFeature({ spread, issue }: EssayFeatureProps) {
 
         <hr className="pop-rule pop-essay-rule" />
 
+        {/* ── Optional dossier: methods-paper abstract card ── */}
+        {spread.dossier && (
+          <aside className="pop-essay-dossier" aria-label="Abstract">
+            <span className="pop-kicker pop-kicker--tomato pop-essay-dossier-kicker">
+              {spread.dossier.kicker}
+            </span>
+            {spread.dossier.note && (
+              <p className="pop-essay-dossier-note">{spread.dossier.note}</p>
+            )}
+            <dl className="pop-essay-dossier-list">
+              {spread.dossier.items.map((item, i) => (
+                <div key={i} className="pop-essay-dossier-row">
+                  <dt className="pop-essay-dossier-label">
+                    <span className="pop-essay-dossier-n">
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="pop-essay-dossier-label-en">{item.label}</span>
+                    {item.labelJp && (
+                      <span className="pop-essay-dossier-label-jp">{item.labelJp}</span>
+                    )}
+                  </dt>
+                  <dd className="pop-essay-dossier-value">
+                    <span className="pop-essay-dossier-value-en">{item.value}</span>
+                    {item.valueJp && (
+                      <span className="pop-essay-dossier-value-jp">{item.valueJp}</span>
+                    )}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </aside>
+        )}
+
         {/* ── Body ────────────────────────────────────────── */}
         <article className="pop-essay-body">
           {spread.sections.map((section, sIdx) => (
@@ -69,9 +102,76 @@ export function EssayFeature({ spread, issue }: EssayFeatureProps) {
                   </p>
                 </aside>
               )}
+
+              {/* Optional "by the numbers" data block — mid-essay. */}
+              {spread.dataBlock && spread.dataBlock.afterSection === sIdx && (
+                <aside className="pop-essay-data" aria-label="By the numbers">
+                  <header className="pop-essay-data-head">
+                    <span className="pop-kicker pop-kicker--tomato">
+                      {spread.dataBlock.kicker}
+                    </span>
+                    {spread.dataBlock.heading && (
+                      <h4 className="pop-essay-data-heading">
+                        {spread.dataBlock.heading}
+                      </h4>
+                    )}
+                    {spread.dataBlock.headingJp && (
+                      <p className="pop-essay-data-heading-jp">
+                        {spread.dataBlock.headingJp}
+                      </p>
+                    )}
+                  </header>
+                  <ul className="pop-essay-data-grid">
+                    {spread.dataBlock.stats.map((stat, i) => (
+                      <li key={i} className="pop-essay-data-stat">
+                        <span className="pop-essay-data-n">{stat.n}</span>
+                        <span className="pop-essay-data-label">{stat.label}</span>
+                        {stat.labelJp && (
+                          <span className="pop-essay-data-label-jp">{stat.labelJp}</span>
+                        )}
+                        {stat.source && (
+                          <span className="pop-essay-data-source">— {stat.source}</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </aside>
+              )}
             </div>
           ))}
         </article>
+
+        {/* ── Optional works-cited block ───────────────────── */}
+        {spread.references && (
+          <aside className="pop-essay-refs" aria-label="Works cited">
+            <header className="pop-essay-refs-head">
+              <span className="pop-kicker pop-kicker--tomato">
+                {spread.references.kicker}
+              </span>
+              {spread.references.note && (
+                <p className="pop-essay-refs-note">{spread.references.note}</p>
+              )}
+            </header>
+            <ol className="pop-essay-refs-list">
+              {spread.references.items.map((ref, i) => (
+                <li key={i} className="pop-essay-refs-item">
+                  <span className="pop-essay-refs-n">
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  <span className="pop-essay-refs-body">
+                    <span className="pop-essay-refs-authors">{ref.authors}</span>
+                    <span className="pop-essay-refs-year"> ({ref.year}). </span>
+                    <span className="pop-essay-refs-title">{ref.title}</span>
+                    {ref.journal && (
+                      <span className="pop-essay-refs-journal">. {ref.journal}</span>
+                    )}
+                    <span className="pop-essay-refs-dot">.</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </aside>
+        )}
 
         {/* ── Sign-off ────────────────────────────────────── */}
         <footer className="pop-essay-signoff">

--- a/src/components/IssueCover.tsx
+++ b/src/components/IssueCover.tsx
@@ -27,10 +27,22 @@ interface IssueCoverProps {
 export function IssueCover({ issue, footer }: IssueCoverProps) {
   const stock = issue.coverStock ?? 'cream'
   const layout = issue.coverLayout ?? 'classic'
-  const sectionClasses = `pop-cover pop-stock-${stock} pop-cover--${layout}`
+  const ornament = issue.coverOrnament
+  const seal = issue.coverSeal
+  const sectionClasses = [
+    'pop-cover',
+    `pop-stock-${stock}`,
+    `pop-cover--${layout}`,
+    ornament ? `pop-cover--ornament-${ornament}` : '',
+    seal ? 'pop-cover--has-seal' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <section className={sectionClasses}>
+      {ornament === 'ink-spread' && <InkSpreadOrnament />}
+      {seal && <CoverSeal label={seal.label} date={seal.date} />}
       <div className="pop-cover-inner">
 
         {/* Top dateline — folio style.
@@ -102,5 +114,115 @@ export function IssueCover({ issue, footer }: IssueCoverProps) {
         {footer}
       </div>
     </section>
+  )
+}
+
+/**
+ * CoverSeal — a press-preview wax seal / rubber stamp rendered
+ * in the cover's top-right corner. The label curves along the
+ * upper arc of a circle; the date sits as a Courier line in the
+ * center; a small star anchors the bottom. Slight rotation
+ * reads as "stamped by hand," not printed.
+ */
+function CoverSeal({ label, date }: { label: string; date: string }) {
+  return (
+    <div className="pop-cover-seal" aria-label={`${label} — ${date}`}>
+      <svg
+        viewBox="0 0 120 120"
+        className="pop-cover-seal-svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <defs>
+          <path
+            id="pop-cover-seal-arc"
+            d="M 16 60 A 44 44 0 0 1 104 60"
+          />
+        </defs>
+        {/* Outer ring */}
+        <circle
+          cx="60"
+          cy="60"
+          r="55"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        />
+        {/* Inner hairline ring */}
+        <circle
+          cx="60"
+          cy="60"
+          r="48"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="0.75"
+          opacity="0.7"
+        />
+        {/* Label curves along the top arc */}
+        <text className="pop-cover-seal-label" fill="currentColor">
+          <textPath href="#pop-cover-seal-arc" startOffset="50%" textAnchor="middle">
+            {label}
+          </textPath>
+        </text>
+        {/* Center date */}
+        <text
+          x="60"
+          y="66"
+          className="pop-cover-seal-date"
+          textAnchor="middle"
+          fill="currentColor"
+        >
+          {date}
+        </text>
+        {/* Little star at the bottom — rubber-stamp flourish */}
+        <polygon
+          points="60,82 62.2,86.8 67.5,87.4 63.5,91 64.7,96.2 60,93.4 55.3,96.2 56.5,91 52.5,87.4 57.8,86.8"
+          fill="currentColor"
+        />
+      </svg>
+    </div>
+  )
+}
+
+/**
+ * InkSpreadOrnament — a tomato ink blot that bleeds off the
+ * lower-right margin of the cover. Two overlapping irregular
+ * shapes plus a few scattered droplets so it reads hand-made,
+ * not geometric. Renders under .pop-cover--ornament-ink-spread.
+ */
+function InkSpreadOrnament() {
+  return (
+    <svg
+      className="pop-cover-ornament pop-cover-ornament--ink-spread"
+      viewBox="0 0 420 420"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <g fill="currentColor">
+        {/* Main blot — irregular, off-kilter */}
+        <path d="M 210 110
+                 C 155 95, 105 135, 110 200
+                 C 95 250, 120 290, 150 315
+                 C 170 355, 230 360, 275 330
+                 C 320 325, 360 295, 355 240
+                 C 380 195, 345 140, 285 135
+                 C 255 100, 230 100, 210 110 Z" />
+        {/* Tail running to the right-bottom corner, bleeds off */}
+        <path d="M 300 310
+                 Q 340 320 380 340
+                 Q 395 350 410 348
+                 L 408 362
+                 Q 365 362 330 348
+                 Q 315 336 300 310 Z" />
+        {/* Splatter droplets — small, scattered, uneven */}
+        <circle cx="380" cy="245" r="5" />
+        <circle cx="95" cy="355" r="4" />
+        <circle cx="360" cy="380" r="7" />
+        <circle cx="250" cy="400" r="3.5" />
+        <circle cx="140" cy="110" r="2.5" />
+        <path d="M 405 280 q 6 2 10 5 l -4 3 q -4 -2 -6 -8 z" />
+        <path d="M 80 260 q -5 3 -9 7 l 6 2 q 3 -3 3 -9 z" />
+      </g>
+    </svg>
   )
 }

--- a/src/components/IssueFeature.tsx
+++ b/src/components/IssueFeature.tsx
@@ -2,6 +2,7 @@ import type { IssueRecord } from '../content/issues'
 import { EssayFeature } from './EssayFeature'
 import { InterviewFeature } from './InterviewFeature'
 import { ForecastFeature } from './ForecastFeature'
+import { DispatchFeature } from './DispatchFeature'
 
 interface IssueFeatureProps {
   issue: IssueRecord
@@ -31,6 +32,8 @@ export function IssueFeature({ issue }: IssueFeatureProps) {
       return <InterviewFeature spread={spread} issue={issue} />
     case 'forecast':
       return <ForecastFeature spread={spread} issue={issue} />
+    case 'dispatch':
+      return <DispatchFeature spread={spread} issue={issue} />
     default: {
       // Exhaustiveness check — adding a new variant without handling
       // it here produces a compile-time error.

--- a/src/content/issues/367.ts
+++ b/src/content/issues/367.ts
@@ -1,23 +1,26 @@
 /* ──────────────────────────────────────────────────────────────
    ISSUE 367 — APRIL 2026
-   THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN
-   モデルが筆を持つ — クロード・デザインについて
+   THE SIEVE: ON PRESELECTION IN BEHAVIORAL GENETICS
+   選別号 — 研究が始まる前の部屋
 
-   The first dispatch-format issue. 364 was the forecast (general
-   outlook, ink + classic). 366 was the essay (narrative, butter +
-   monument-hero). 367 introduces a fourth tool: the wire dispatch,
-   filed against a deadline the night a specific event happened —
-   in this case the launch of Anthropic Labs' first product.
+   An essay on the quiet moment before a behavioral-genetics study
+   begins — the one where the sample is chosen, the twins enrolled,
+   the questionnaires answered. Every heritability number downstream
+   is a statement about who made it into the room. This issue walks
+   the sieve slowly and itemizes what falls through.
 
-   Identity — ivory stock + asymmetric-left layout + ink-spread
-   cover ornament + dispatch spread type. Ivory reads as press-
-   preview white, the paper a launch arrives printed on; the
-   asymmetric-left lockup reads as a bulletin filed on deadline;
-   the tomato ink-spread literalises the swash ("we watch the ink
-   spread"); and the dispatch grammar — wire slug marquee,
-   dateline, dossier card, checkbox numbering, mid-spread
-   bulletin, bridge line to issue 366 — makes the magazine feel
-   serialised rather than episodic.
+   Ink stock + asymmetric-left layout — first run of this combo.
+   Dark paper reads archival, specimen-label serious; asymmetric-
+   left gives the magazine's most technical topic an editorial-
+   column rhythm instead of a monument. A study number on the
+   front page of a methods paper, rendered at magazine weight.
+
+   8 sections, expanded over the first cut — Biobank volunteer
+   bias, twin-registry ascertainment, self-report truncation,
+   GWAS ancestry skew, clinical vs population sieves, the
+   Pirastu "participation-as-phenotype" finding, the missing-
+   heritability gap, and a closing cultural turn back on the
+   magazine itself.
    ────────────────────────────────────────────────────────────── */
 
 import type { IssueRecord } from './index'
@@ -26,178 +29,279 @@ export const ISSUE_367: IssueRecord = {
   number: '367',
   month: 'APRIL',
   year: '2026',
-  feature: 'THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN',
-  featureJp: 'モデルが筆を持つ — クロード・デザインについて',
+  feature: 'THE SIEVE: ON PRESELECTION IN BEHAVIORAL GENETICS',
+  featureJp: '選別号 — 研究が始まる前の部屋',
   price: '¥0 · BYOK',
   tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
-  /** Cover identity — ivory + asymmetric-left + ink-spread.
-      Combination is unique in the run: ivory has never been
-      paired with an ornament, and the ink-spread ornament is
-      dispatch-exclusive. The result is a cover that reads as a
-      press-preview page with a tomato blot drying in the lower
-      right — a physical object, a bulletin, not UI chrome. */
-  coverStock: 'ivory',
+  /** Cover identity — ink stock + asymmetric-left layout. First
+      use of this combination. Dark paper gives the issue an
+      archival, specimen-label seriousness; asymmetric-left slots
+      the magazine's most technical topic into an editorial column
+      rather than a monument. The cover reads like the front page
+      of a methods paper rendered at magazine weight. */
+  coverStock: 'ink',
   coverLayout: 'asymmetric-left',
-  coverOrnament: 'ink-spread',
-
-  /** Press-preview wax seal, top-right corner. Reads as a
-      rubber stamp pressed on the cover before the magazine
-      left the press. Pairs with the ink-spread ornament to
-      make the cover feel like a physical proof, not a web
-      page. */
-  coverSeal: {
-    label: 'EMBARGO LIFTED',
-    date: 'IV\u00b726',
-  },
 
   headline: {
-    prefix: 'The Model',
-    emphasis: 'Picks Up',
-    suffix: 'the Pen.',
-    swash: 'Anthropic opens a design room; we watch the ink spread.',
+    prefix: 'The',
+    emphasis: 'Sieve',
+    suffix: 'Issue',
+    swash: 'Who gets counted, and who doesn\u2019t, in behavioral genetics.',
   },
 
   contents: [
-    { n: '001', en: 'The empty canvas closes', jp: '白紙の終焉', tag: 'FIELD' },
-    { n: '002', en: 'A Labs coat, not a hoodie', jp: '実験室の白衣', tag: 'FRAMING' },
-    { n: '003', en: 'Who they brought to the party', jp: '招待された名前', tag: 'PARTNERS' },
-    { n: '004', en: 'Inline comments, meet the prompt', jp: '注釈とプロンプト', tag: 'INTERFACE' },
-    { n: '005', en: 'Figma hears the door', jp: 'フィグマ、扉の音', tag: 'COMPETITION' },
-    { n: '006', en: 'What stays scarce', jp: '残る希少', tag: 'TASTE' },
-    { n: '007', en: 'The only real question', jp: '唯一の問い', tag: 'FUTURE' },
+    { n: '001', en: 'Who the study finds', jp: 'サンプルの限界', tag: 'METHOD' },
+    { n: '002', en: 'The willing twin', jp: '応じる双子', tag: 'REGISTRY' },
+    { n: '003', en: 'The honest self-report', jp: '自己申告の限界', tag: 'MEASURE' },
+    { n: '004', en: 'What ancestry filters', jp: '祖先というフィルター', tag: 'ANCESTRY' },
+    { n: '005', en: 'The clinic isn\u2019t the world', jp: '病院の外', tag: 'CLINICAL' },
+    { n: '006', en: 'Participation as phenotype', jp: '参加することの遺伝性', tag: 'PARTICIPATION' },
+    { n: '007', en: 'The missing heritability', jp: '見えない遺伝率', tag: 'GAP' },
+    { n: '008', en: 'What escapes the sieve', jp: '網からこぼれるもの', tag: 'ESSAY' },
   ],
 
   spread: {
-    type: 'dispatch',
-    kicker: 'DISPATCH · 速報',
-    title: 'The Model Picks Up the Pen.',
-    titleJp: 'モデルが筆を持つとき。',
-    deck: 'Seven stakes filed the night Anthropic Labs shipped Claude Design. What just shifted, who should be nervous, what stays scarce, and the only question that still matters by summer.',
+    type: 'essay',
+    kicker: 'METHOD SPREAD · 方法論',
+    title: 'The Room Before the Study.',
+    titleJp: '研究が始まる前の部屋。',
+    deck: 'Notes on preselection in behavioral genetics — what the field can see, what it can\u2019t, and why the answer depends on who walked into the room first.',
     byline: 'BY THE EDITORS \u00b7 KERNEL.CHAT',
-    stock: 'ivory',
+    stock: 'ink',
 
-    /** Wire slug — repeats across the top marquee. Reads as
-        newsroom ticker tape. Short, Courier, all caps. */
-    slug: 'KERNEL.CHAT WIRE \u00b7 367 \u00b7 IV\u00b726 \u00b7 FILED 23:47 JST \u00b7 INK WET \u00b7 EMBARGO LIFTED',
-
-    /** Newspaper dateline — read as if spoken by the wire. */
-    dateline: 'SAN FRANCISCO \u2014 APR 17 \u2014 THE EDITORS FILED THIS LATE.',
-
-    /** Dossier stamp fields. */
-    filedAt: '17 APR 2026 \u00b7 23:47 JST',
-    status: 'INK WET',
-
-    /** The partner roll — triangulates the launch audience. */
-    partners: [
-      { name: 'CANVA', role: 'the mass-market channel; half a billion monthly cards.' },
-      { name: 'BRILLIANT', role: 'the learning surface; the next generation of designers discovers the idea here.' },
-      { name: 'DATADOG', role: 'the enterprise column; the line item that pays for the GPUs.' },
-    ],
-
-    /** Bridge to the preceding issue — makes 366 + 367 read as
-        two halves of the same argument. */
-    bridge: {
-      issue: '366',
-      text: '366 watched the tools use us. 367 is the night one of them picked up a pen.',
-    },
-
-    intro: 'Anthropic launched a design product last night. Not a model. Not an API. A tool where you describe what you want, and a model renders it — mockups, prototypes, decks, marketing collateral, code-driven surfaces with voice and shader and 3D. The launch partners were Canva, Brilliant, and Datadog. The framing was "Anthropic Labs," a new division for experimental things. We filed these notes the same night, before the takes industrialised. Some of them will be wrong by June. That is the nature of filing fast.',
-
-    propositions: [
+    sections: [
       {
-        n: '01',
-        overline: 'FIELD',
-        filedAt: '23:12 JST',
-        title: 'The empty canvas is over.',
-        titleJp: '白紙の終焉',
-        body: [
-          'First-draft-for-free arrived for copy in 2023 and for code shortly after. It has now arrived for design. The blank artboard — the scariest hour of the working day, the one where taste is actually formed — has been declared solved by a company that is, on current evidence, good at declaring things solved and then shipping them.',
-          'Whether this is good for designers is a different question from whether it is true. The empty canvas was not only a problem. It was also where the hand learned what the hand wanted to make.',
+        heading: 'WHO THE STUDY FINDS',
+        headingJp: 'サンプルの限界',
+        paragraphs: [
+          'A behavioral-genetics study is a machine that turns measurements of people into statements about human nature. The machine works — it has given us the heritability of intelligence, the family risk of schizophrenia, the twin studies that underpin a century of developmental psychology, the polygenic scores that are beginning, tentatively and imperfectly, to enter clinical practice. What the machine cannot do is study people it does not find. Every number it produces is a statement about the subset of humans who agreed to be measured, and the field has been, for most of its history, strangely quiet about who that subset is.',
+          'The UK Biobank is the largest and most celebrated behavioral-genetics resource of the last decade — half a million volunteers, deep phenotyping, linked medical records, open-access summary statistics that have powered thousands of papers. Its participants are, on average, five years older, wealthier, better-educated, more female, and measurably healthier than the UK population it was meant to represent. The response rate at recruitment was 5.5 percent. The people who said yes were not the British; they were a self-selected slice of the British — the retired schoolteacher in Hampshire who reads the local paper, the civil servant in Leeds who likes the idea of contributing to science. Every heritability estimate derived from the Biobank is a statement about that slice. The field calls this "healthy-volunteer bias." The quieter name for it is the sieve.',
+          'The polite word for this in the methods section is "selection bias." The honest word is preselection — the sieve runs before the study begins, and the study only ever measures what the sieve lets through. A heritability of 0.40 on Biobank neuroticism is not wrong. It is a precise, defensible number about a sample of volunteers. What it is not is a number about the species. The distinction is methodological and it is also moral; statements about human nature tend to get written as if they applied to humans.',
+          'Preselection in this field is not new. Francis Galton, the Victorian statistician who founded behavioral genetics, recruited his subjects from the educated professional classes of Kensington because those were the people he knew how to reach. A century later Cyril Burt\'s twin-study ascertainment, never fully documented and still contested, seeded the field with numbers whose provenance could not be audited. Modern behavioral genetics inherited those habits and, to its credit, has been slowly replacing them with pre-registered protocols, published recruitment trees, and open data. The habits are not gone. They are now named.',
         ],
       },
       {
-        n: '02',
-        overline: 'FRAMING',
-        filedAt: '23:18 JST',
-        title: 'The Labs coat is not a hoodie.',
-        titleJp: '実験室の白衣',
-        body: [
-          'Anthropic did not launch this as "Claude Design, a new product." They launched it as "Anthropic Labs, which makes experimental things, and here is its first one." The framing is a hedge — Labs can fail; the mainline Claude brand cannot. It is also a commitment. The company that spent three years insisting its model is a tool for thought now has a division whose job is to ship consumer software that looks and feels.',
-          'Watch where the Labs work ends up. The good stuff will be folded into Claude proper within a year. The rest will be quietly retired, and the Labs frame will have absorbed the failure so the brand does not have to.',
+        heading: 'THE WILLING TWIN',
+        headingJp: '応じる双子',
+        paragraphs: [
+          'The twin study is the jewel of the field and the oldest, cleanest instrument behavioral genetics owns. Compare identical twins to fraternal twins on a trait; the gap between the correlations, roughly, is the additive genetic contribution. The Scandinavian registries — Swedish, Danish, Finnish — come closer than any other resource on earth to enrolling the full population of twins. They are the gold standard. They still preselect.',
+          'The twins who enroll are the twins who can be reached, who are alive, who remain in contact with each other, who return the questionnaire. Twins estranged from their co-twin drop out. Twins whose co-twin has died drop out. Twins whose co-twin has a severe psychiatric condition drop out at elevated rates, because severe illness correlates with disengagement from research. The concordance figure that results is the concordance among twins close enough to both be in the registry at the same time. A trait whose expression drives twins apart will show a lower concordance than the underlying genetics implies, and the field has no clean way of correcting for this.',
+          'The reared-apart twin studies — Bouchard\'s Minnesota cohort from the 1980s is the canonical example — were methodologically brilliant and ascertainment-fragile in ways that still provoke argument. Twins who were adopted apart, found each other, agreed to travel to Minneapolis, and consented to a week of testing are a vanishing sliver of possible adoptees. Their very existence as a study sample is a selected outcome. The famous heritability numbers that came out of Minnesota — intelligence around 0.70, personality around 0.50 — are among the most-cited in the field. They are also among the most honestly qualified, in the original papers, by acknowledgments of how the sample was assembled.',
+          'None of this invalidates twin studies. It does mean that the single number produced — 0.60 heritable, 0.20 shared environment, 0.20 unique environment — is a summary of a quiet negotiation between what the trait is and who the trait lets you enroll. The ACE model that decomposes those three components assumes no assortative mating, no gene-environment correlation, no gene-environment interaction. Every one of those assumptions is wrong in minor ways and sometimes wrong in major ways. The cleanest instrument still has a sieve upstream of it.',
         ],
       },
       {
-        n: '03',
-        overline: 'PARTNERS',
-        filedAt: '23:24 JST',
-        title: 'Look at who they brought to the party.',
-        titleJp: '招待された名前',
-        body: [
-          'Canva. Brilliant. Datadog. That triangulation is not accidental. Canva is the mass market — half a billion people who have never opened Figma and make one birthday card a month. Brilliant is the learning channel — the surface where the next generation of designers discovers the idea that "designing" is something a person does. Datadog is the enterprise column, the one whose line item pays for the GPUs.',
-          'Read a launch partner list the way you read a band\u2019s touring cities. It tells you which rooms are being played first, and in what order the rest will follow.',
+        heading: 'THE HONEST SELF-REPORT',
+        headingJp: '自己申告の限界',
+        paragraphs: [
+          'Most behavioral traits are measured by asking people about themselves. A five-factor personality inventory, a depression screener, a substance-use questionnaire — these instruments assume a respondent with a stable enough sense of self to answer, a literate enough reader to parse the question, and a motivated enough participant to answer honestly across two hundred items. Each of those assumptions is a filter. Each filter removes a non-random slice of the population.',
+          'Depression is the canonical example. Severe depression lowers the probability of completing a depression questionnaire. The people whose depression is worst are the people least likely to be measured, which means the distribution of "depression" in a research dataset is truncated on the side that matters most. Heritability of self-reported depression is therefore partly the heritability of "willingness and capacity to describe yourself as depressed" — a trait that is real, heritable, and not the same thing as depression. The Dunedin Study, which interviews self, teachers, parents, and peers at every wave since 1972, is the rare longitudinal design that tries to get underneath this; its sample size is a few thousand. The big GWAS datasets rely on self-report alone because that is what scales.',
+          'Self-report also assumes a stable signifier — that "neurotic" or "conscientious" means the same thing across respondents. Psychometric research has pushed back on this for decades. Measurement invariance tests ask whether the items of a scale are operating the same way across subgroups; they often find they are not. The "openness" of a 22-year-old and the "openness" of a 68-year-old are not the same latent trait dressed in the same words, and when heritability is computed across an age-mixed sample, the resulting number is partly a measurement artifact. Researchers who spend their careers on this problem — Roberts, Soto, the Big Five psychometricians — have been flagging it in the literature for years. It is slow to filter downstream into applied GWAS work.',
+          'The language of the field has quietly absorbed this. Papers now distinguish "broad depression" (endorsed one item on a phone-based screener) from "strict depression" (met DSM criteria in a clinical interview). The genetic correlation between the two is high but not one. They are related traits. They are not the same trait. One of them is what self-report can find; the other is what the clinic can find. Between them falls the population neither caught.',
         ],
       },
       {
-        n: '04',
-        overline: 'INTERFACE',
-        filedAt: '23:31 JST',
-        title: 'Inline comments is a borrowed metaphor.',
-        titleJp: '注釈とプロンプト',
-        body: [
-          'The interface imports a Figma metaphor — comments next to work, custom adjustment controls, a conversational loop — into a place where the work itself is being generated by the same system you are commenting to. This is new. You are no longer a designer commenting on a designer\u2019s draft. You are a reviewer commenting on a reviewer that wrote the draft, will revise the draft based on your comment, and then invite you to comment on the revision.',
-          'The metaphor fits poorly. The product will force the industry to find a new one. The first company to name the interaction well — the right verb for the thing you are doing when you nudge a generated artefact with prose — wins the vocabulary of the next decade of design tools.',
+        heading: 'WHAT ANCESTRY FILTERS',
+        headingJp: '祖先というフィルター',
+        paragraphs: [
+          'The most consequential preselection in modern behavioral genetics is ancestry. As of the mid-2020s, roughly 86 percent of participants in published genome-wide association studies were of European ancestry. East Asian ancestry accounted for about 10 percent; African ancestry for about 2 percent; every other global population shared the remaining sliver. A polygenic score trained on this evidence base predicts a European-ancestry outcome with reasonable skill and loses something like seventy percent of its predictive power when applied to people of African descent. Martin and colleagues documented this cleanly in 2019 (Nature Genetics); the result has been replicated many times since. This is not a finding about biology. It is a finding about the enrollment funnel.',
+          'The reasons are sociological as much as scientific. The first large biobanks were built in countries with majority-European populations and recruitment channels that favored trusting, research-adjacent communities. Those channels have not historically been open to populations with legitimate reasons to distrust medical research — the Tuskegee syphilis study, the Havasupai diabetes case, the long postcolonial history of bodies studied without consent are not abstractions to the communities that lived them. The field is aware of this and has been investing in cohorts like All of Us, H3Africa, and BioMe to broaden the base, but parity is a decade off at the earliest, and the polygenic scores being deployed today — including those sold to consumers through direct-to-consumer genomics companies — are trained on what exists now, not on what is coming.',
+          'The technical consequences compound. Linkage disequilibrium patterns differ across ancestries; a variant tagged in Europeans may not be tagged at all in another population because the local haplotype structure is different. Allele frequencies differ; a variant common enough to power a European GWAS may be too rare elsewhere to detect with any sample size currently achievable. The translation of a European polygenic score to a non-European individual is not a simple scaling problem. It is an extrapolation across population-genetic terrain the original study never mapped.',
+          'The honest framing is that the current genetics of behavior is not the genetics of human behavior. It is the genetics of human behavior in people whose ancestors are overrepresented in research datasets, which is a more specific and much smaller claim. The work to make the claim general is ahead of the field, not behind it.',
         ],
       },
       {
-        n: '05',
-        overline: 'COMPETITION',
-        filedAt: '23:38 JST',
-        title: 'Figma hears the door.',
-        titleJp: 'フィグマ、扉の音',
-        body: [
-          'If Canva is a public launch partner for Claude Design, Figma is reading the same announcement and running the same arithmetic. The layer of software where "make me a mockup" becomes the default interaction is being restructured in real time, and the company whose entire identity was "we own that layer" has reason to be, quietly, not sleeping well tonight.',
-          'Expect acquisition chatter. Expect pivot rumours. Expect a counter-product announcement before the end of the quarter. The air changed tonight. Whether the ground moves depends on who executes first.',
+        heading: 'THE CLINIC ISN\u2019T THE WORLD',
+        headingJp: '病院の外',
+        paragraphs: [
+          'The alternative to population-based recruitment is clinical ascertainment — study the people the healthcare system has already identified as having the condition. This solves some problems and creates others. A schizophrenia genetics study recruited from inpatient units will find severe, treatment-contact cases and miss the population with attenuated psychotic symptoms who never see a psychiatrist. A bipolar study through specialist clinics oversamples the well-resourced patients who made it into specialty care and undersamples the patients who cycle through emergency rooms and primary care without ever reaching a diagnosis that sticks.',
+          'Every diagnostic label is itself a sieve, upstream of the genetic study. Who gets diagnosed with ADHD, who gets diagnosed with autism, who gets diagnosed with personality disorder — these are questions answered in part by biology and in part by which clinician saw which child in which school district with which insurance. A GWAS of "diagnosed ADHD" is a GWAS of the disposition to receive that diagnosis, which includes genuine neurobiology and also includes the social sieve that routed particular children toward particular clinicians. The two contributions are confounded in the resulting summary statistics, and no analytic technique currently pulls them apart cleanly.',
+          'Clinical trials have their own ascertainment. STAR*D, the largest US depression treatment trial, recruited patients who were willing to be randomized into a stepped-care protocol; its response rates and side-effect profiles are indispensable, and they describe a specific slice of depressed Americans — mostly insured, mostly primary-care-reached, mostly willing to tolerate a research protocol on top of a clinical one. The generalizations from STAR*D to "depression" in general are routine in the literature and routinely too broad. Treatment studies, like genetic studies, describe the population they managed to recruit.',
+          'The field\u2019s best response is triangulation — combine clinical and population samples, compare polygenic predictions across settings, flag when the two diverge. What the field cannot do is pretend either sieve is neutral. Both are loaded. They are loaded differently, and the honest report names which loading produced which number.',
         ],
       },
       {
-        n: '06',
-        overline: 'TASTE',
-        filedAt: '23:42 JST',
-        title: 'What stays scarce: taste.',
-        titleJp: '残る希少',
-        body: [
-          'First drafts are free. Thousand-draft exploration is free. What is not free — and is getting more valuable by the quarter — is the person who can look at forty generated options and know that thirty-seven are the same idea in different fonts, that two are technically interesting and wrong for this audience, and that the last one, the ugly one, is the one worth pursuing. That is editorial work. No Labs product ships it as a feature.',
-          'The premium on taste just went up, not down. The designers who survive the next two years will be the ones who can say, plainly and without flinching, why one option is better than another. The ones who cannot will be managed by those who can.',
+        heading: 'PARTICIPATION AS PHENOTYPE',
+        headingJp: '参加することの遺伝性',
+        paragraphs: [
+          'The strangest finding in the literature on preselection is the one that turns the problem on its head. In 2021, Pirastu and colleagues published a paper (Nature Genetics) showing that participation in research is itself a heritable trait. They ran genome-wide association studies on completion of follow-up surveys inside the UK Biobank, on return of mail-in questionnaires inside the Avon Longitudinal Study, on willingness to wear an accelerometer for a week. They found robust, replicable genetic signal for all of it. The willingness to fill out forms is, to a modest but measurable degree, in the genes.',
+          'That finding would be a curiosity if it ended there. It does not. Participation is genetically correlated with the traits the field studies — higher body mass, lower cognitive-test performance, more psychiatric symptomatology are all associated, genetically, with lower participation. This means that when a GWAS of, say, depression is run inside a cohort, the variants that push people toward depression are the same variants that pushed some would-be participants out of the cohort before they could be measured. The ascertainment bias is not just demographic. It is at the level of the allele.',
+          'The practical consequence is that conventional GWAS summary statistics on behavioral traits are biased estimators of the genetic architecture of those traits, and the bias is in the same direction as the trait itself. This is a harder problem than the ancestry problem. The ancestry problem can be addressed by recruiting more diverse cohorts; the participation problem cannot be solved by recruiting, because the people who are not participating are, by definition, not there to recruit. The methodological fix is to model participation as a latent trait alongside the one you care about, using whatever auxiliary data you have about non-responders — a technique still being refined, still controversial, and not yet standard.',
+          'The deeper point is philosophical. Every behavioral-genetics finding is a claim about a trait as expressed in a sample that was willing to be measured for that trait. The measurement process is not external to the phenomenon. It is part of the phenomenon. This is a discomfiting thing to tell a field built on the premise that the measurement and the trait are separable.',
         ],
       },
       {
-        n: '07',
-        overline: 'FUTURE',
-        filedAt: '23:46 JST',
-        title: 'The only real question.',
-        titleJp: '唯一の問い',
-        body: [
-          'Does Claude Design produce outputs designers want to argue with? That is the only question that matters. The outputs you argue with are the ones you keep open and keep changing. The outputs you shrug at are the ones you close the tab on, and the product that produces them gets churned off within ninety days regardless of how impressive the launch partners were.',
-          'We will find out by summer. Until then the pen is in a new hand, the ink is still wet, and the line it draws is the only thing worth watching. Not the press release. The line.',
+        heading: 'THE MISSING HERITABILITY',
+        headingJp: '見えない遺伝率',
+        paragraphs: [
+          'For a decade after the first GWAS wave of 2007, the field talked openly about a puzzle it called "the missing heritability." Twin studies had estimated the heritability of adult height at around 0.80 — remarkably stable across cohorts, across decades, across populations. Early GWAS, with their few hundred genome-wide-significant variants, could account for only a few percent of the variance. A gap of seventy percentage points sat between the twin number and the molecular number. The gap was named in a 2008 editorial (Maher, Nature), formalized in a 2009 review (Manolio et al., Nature), and spent the next fifteen years being chipped away at from both sides.',
+          'The molecular side has closed most of the gap for simple traits. Height is now about 0.40–0.50 by GWAS — the remainder chalked up to rare variants, structural variation, and better methods for capturing common-variant tagging (Yang, Visscher, and collaborators). For behavioral traits the gap is still enormous. Educational attainment, one of the most heavily studied behavioral outcomes, shows a twin-study heritability near 0.40 and a GWAS-estimated SNP-heritability around 0.12 once you restrict to populations where the estimates are meaningful. The arithmetic of the missing heritability has always been phrased as if the twin number were true and the GWAS number were incomplete. The preselection literature suggests the error bars run in both directions.',
+          'Twin-study heritability is inflated when assortative mating is present — when partners resemble each other on the trait, which they do for education and cognitive measures. The ACE decomposition assigns that resemblance to shared genes rather than to non-random mating, and the shared-genes estimate goes up. GWAS heritability is deflated by ancestry restriction, by self-report truncation, by the Pirastu participation effect, and by the fact that the cohorts doing the measuring are not samples of humans in the way the math assumes. The gap between the two numbers is not a single underestimate. It is a pair of biased estimators pointing at the same latent quantity from different directions, and the truth — if "the heritability" is even a well-defined quantity — is somewhere in a region neither arrow is currently reaching.',
+          'This is not a crisis. It is the field doing the work. But it is worth naming what the work actually is. Heritability is not a property of a trait. It is a property of a population measured in a particular way under particular conditions. Different sieves produce different numbers. None of them is the number.',
+        ],
+      },
+      {
+        heading: 'WHAT ESCAPES THE SIEVE',
+        headingJp: '網からこぼれるもの',
+        paragraphs: [
+          'What escapes the sieve is not random. That is the one sentence worth taking from this issue. The people who do not enroll in biobanks, who do not respond to surveys, who lost touch with their twin, whose ancestry is underrepresented, who never reached the clinic, whose genotypes predispose them to opt out of the forms — they are structured populations, not noise, and the traits that caused them to fall through are often the traits the study was trying to measure. A behavioral-genetics result computed on the surviving sample will be biased in a direction the methods section rarely names.',
+          'Eric Turkheimer — one of the clearest-eyed writers the field has — has argued for twenty years that heritability is nearly universal (his "first law"), nearly uninformative about mechanism (a corollary), and almost always smaller, in its useful causal sense, than the number seems to imply. He is not a critic from the outside. He is a behavioral geneticist making the field honest about what its numbers can do. The preselection story is one more reason to read him closely. The number is real. The number is not what it looks like. These can both be true.',
+          'The correction is not to stop doing the science. The science has produced real, replicable, useful findings about human variation, and stopping would be a loss. The correction is to publish the sieve alongside the number — who was invited, who said yes, who completed, who dropped out, whose ancestry is represented, whose is not, and what the evidence suggests about how those stages depend on the trait under study. A few of the better-run cohorts are beginning to do this. Most still do not. The field would be more honest, and the findings more durable, if every heritability estimate came stapled to its ascertainment narrative.',
+          'A last observation, from a magazine not usually in the methods business: every study of humans begins with the decision of who gets studied, and that decision is almost never neutral. This is true of behavioral genetics. It is also true of the design research that informs the software on your desk, the consumer surveys that set your product roadmap, the academic ethnographies that get written into the next round of tools, the magazine subscriptions that define the audience a magazine believes it is writing for. kernel.chat, it should be said, studies coders who read magazines about coders. The sieve is always there. Naming it does not close it. Not naming it guarantees the wrong story gets told.',
         ],
       },
     ],
 
-    /** Mid-spread bulletin — the sharpest line lifted out of the
-        propositions and set as a wire billboard. */
-    bulletin: {
-      text: 'The premium on taste just went up, not down.',
-      attribution: 'KERNEL.CHAT \u00b7 DISPATCH \u00b7 367',
+    pullQuote: {
+      text: 'Every heritability number is a statement about a sample. The sample is never the species.',
+      attribution: 'KERNEL.CHAT \u00b7 EDITORIAL',
     },
 
-    outro: 'Dispatches get older fast. File this one under APR 2026, next to the take that looked obvious that week and foolish by August. Some of it will hold. The parts that hold are the parts about taste — because taste is always what survives a tool-shift, and there has never been a tool-shift that rewarded the people who did not have any.',
+    /** Opening register — editorial dossier card. Sits between
+        the essay head and the first section, introducing the
+        subject the way a fashion magazine would: numbered,
+        catalog-typeset, the issue's frame before the prose. */
+    dossier: {
+      kicker: 'THE REGISTER \u00b7 \u8981\u7db1',
+      note: 'The frame of the issue, laid out the way a magazine lays out its subject before the essay begins.',
+      items: [
+        {
+          label: 'Subject',
+          labelJp: '\u4e3b\u984c',
+          value: 'Preselection in behavioral genetics \u2014 the decision of who gets studied, made before any study begins.',
+        },
+        {
+          label: 'Field',
+          labelJp: '\u5206\u91ce',
+          value: 'Human behavior genetics, from Galton\u2019s 1869 \u201cHereditary Genius\u201d to the biobank era.',
+        },
+        {
+          label: 'Instruments',
+          labelJp: '\u9053\u5177',
+          value: 'Twin registries, population biobanks, genome-wide association studies, polygenic scores.',
+        },
+        {
+          label: 'The sample',
+          labelJp: '\u6a19\u672c',
+          value: '5.5 percent of those invited to the UK Biobank. 86 percent of GWAS participants of European ancestry. A sliver of the species that said yes.',
+        },
+        {
+          label: 'The hidden variable',
+          labelJp: '\u96a0\u308c\u305f\u5909\u6570',
+          value: 'The people who declined. Structured, non-random, correlated with the traits the field tries to measure.',
+        },
+        {
+          label: 'The quiet claim',
+          labelJp: '\u9759\u304b\u306a\u4e3b\u5f35',
+          value: 'Every heritability number is a statement about a sample. The sample is never the species.',
+        },
+      ],
+    },
 
-    signoff: '\u8857\u306e\u30b3\u30fc\u30c0\u30fc\u305f\u3061\u3078 \u2014 watch the first marks, not the press release.',
+    /** The Figures — editorial "by-the-numbers" block. Placed
+        after the clinic section (index 4) so it lands between
+        the five methodological sections and the two newer
+        structural ones (participation, missing heritability). */
+    dataBlock: {
+      kicker: 'THE FIGURES \u00b7 \u6570\u5b57',
+      heading: 'The sieve, in six statistics.',
+      headingJp: '\u7db2\u306b\u6b8b\u3063\u305f\u3082\u306e\u3001\u516d\u3064\u306e\u6570\u5b57\u3067\u3002',
+      afterSection: 4,
+      stats: [
+        {
+          n: '5.5%',
+          label: 'of invited UK residents returned the UK Biobank consent and completed baseline enrollment. The rest, by definition, are not in the dataset.',
+          source: 'UK Biobank recruitment, 2006\u20132010',
+        },
+        {
+          n: '86%',
+          label: 'of participants in published genome-wide association studies were of European ancestry at the last audit. The remaining 14 percent carry the weight of every non-European claim the field makes.',
+          source: 'GWAS diversity audit, mid-2020s',
+        },
+        {
+          n: '\u221270%',
+          label: 'predictive power lost when a polygenic score trained on European-ancestry participants is applied to individuals of African descent. A sampling artifact, not a biological one.',
+          source: 'Martin et al., Nat Genet 2019',
+        },
+        {
+          n: '0.40 \u2192 0.12',
+          label: 'twin-study heritability of educational attainment, versus GWAS SNP-heritability of the same trait. The gap is the field\u2019s oldest unresolved debt.',
+          source: 'Manolio et al., Nat 2009',
+        },
+        {
+          n: 'h\u00b2 > 0',
+          label: 'heritability of research participation itself \u2014 willingness to complete the survey is in the genes, and the variants correlate with the traits the surveys try to measure.',
+          source: 'Pirastu et al., Nat Genet 2021',
+        },
+        {
+          n: '1869',
+          label: 'year Galton published \u201cHereditary Genius\u201d and recruited his subjects from the educated professional classes of Kensington. The sieve began here.',
+          source: 'Galton, \u201cHereditary Genius,\u201d 1869',
+        },
+      ],
+    },
 
-    /** AP-style wire terminator. "— 30 —" closed dispatches on the
-        teletype; the text below is the filing summary. */
-    terminator: 'END OF DISPATCH \u00b7 KERNEL.CHAT/367 \u00b7 FILED 23:47 JST \u00b7 INK STILL WET',
+    /** Further reading — editorial back matter. Named studies
+        with one-line editorial glosses. Colophon-adjacent, not
+        footnote-adjacent; the magazine tells you where to keep
+        reading, it does not impersonate a reference manager. */
+    references: {
+      kicker: 'FURTHER \u00b7 \u53c2\u8003',
+      note: 'Selected reading, in the order the essay touches them. One-line editorial notes, not citations.',
+      items: [
+        {
+          authors: 'Galton, F.',
+          year: '1869',
+          title: 'Hereditary Genius',
+          journal: 'Macmillan \u2014 the founding document of the field, and the first preselected sample',
+        },
+        {
+          authors: 'Bouchard, T. J. et al.',
+          year: '1990',
+          title: 'Sources of human psychological differences: the Minnesota study of twins reared apart',
+          journal: 'Science \u2014 the reared-apart study whose methods still provoke argument',
+        },
+        {
+          authors: 'Maher, B.',
+          year: '2008',
+          title: 'Personal genomes: the case of the missing heritability',
+          journal: 'Nature \u2014 the editorial that named the gap',
+        },
+        {
+          authors: 'Manolio, T. A. et al.',
+          year: '2009',
+          title: 'Finding the missing heritability of complex diseases',
+          journal: 'Nature \u2014 the formal framing of the problem',
+        },
+        {
+          authors: 'Turkheimer, E.',
+          year: '2000',
+          title: 'Three laws of behavior genetics and what they mean',
+          journal: 'Current Directions in Psychological Science \u2014 the clearest-eyed interpreter the field has',
+        },
+        {
+          authors: 'Martin, A. R. et al.',
+          year: '2019',
+          title: 'Clinical use of current polygenic risk scores may exacerbate health disparities',
+          journal: 'Nature Genetics \u2014 the canonical portability paper',
+        },
+        {
+          authors: 'Pirastu, N. et al.',
+          year: '2021',
+          title: 'Genetic analyses identify widespread sex-differential participation bias',
+          journal: 'Nature Genetics \u2014 participation itself is heritable; the deepest form of preselection yet named',
+        },
+        {
+          authors: 'Yang, J., Visscher, P. M. et al.',
+          year: '2010\u2013present',
+          title: 'GCTA and successor methods for SNP-heritability estimation',
+          journal: 'Various \u2014 the closing arithmetic on the missing-heritability debt',
+        },
+      ],
+    },
+
+    signoff: '\u7814\u7a76\u306e\u524d\u306b \u2014 before the data speaks, the sample has already chosen what it can say.',
   },
 
   credits: {

--- a/src/content/issues/367.ts
+++ b/src/content/issues/367.ts
@@ -1,0 +1,211 @@
+/* ──────────────────────────────────────────────────────────────
+   ISSUE 367 — APRIL 2026
+   THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN
+   モデルが筆を持つ — クロード・デザインについて
+
+   The first dispatch-format issue. 364 was the forecast (general
+   outlook, ink + classic). 366 was the essay (narrative, butter +
+   monument-hero). 367 introduces a fourth tool: the wire dispatch,
+   filed against a deadline the night a specific event happened —
+   in this case the launch of Anthropic Labs' first product.
+
+   Identity — ivory stock + asymmetric-left layout + ink-spread
+   cover ornament + dispatch spread type. Ivory reads as press-
+   preview white, the paper a launch arrives printed on; the
+   asymmetric-left lockup reads as a bulletin filed on deadline;
+   the tomato ink-spread literalises the swash ("we watch the ink
+   spread"); and the dispatch grammar — wire slug marquee,
+   dateline, dossier card, checkbox numbering, mid-spread
+   bulletin, bridge line to issue 366 — makes the magazine feel
+   serialised rather than episodic.
+   ────────────────────────────────────────────────────────────── */
+
+import type { IssueRecord } from './index'
+
+export const ISSUE_367: IssueRecord = {
+  number: '367',
+  month: 'APRIL',
+  year: '2026',
+  feature: 'THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN',
+  featureJp: 'モデルが筆を持つ — クロード・デザインについて',
+  price: '¥0 · BYOK',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
+
+  /** Cover identity — ivory + asymmetric-left + ink-spread.
+      Combination is unique in the run: ivory has never been
+      paired with an ornament, and the ink-spread ornament is
+      dispatch-exclusive. The result is a cover that reads as a
+      press-preview page with a tomato blot drying in the lower
+      right — a physical object, a bulletin, not UI chrome. */
+  coverStock: 'ivory',
+  coverLayout: 'asymmetric-left',
+  coverOrnament: 'ink-spread',
+
+  /** Press-preview wax seal, top-right corner. Reads as a
+      rubber stamp pressed on the cover before the magazine
+      left the press. Pairs with the ink-spread ornament to
+      make the cover feel like a physical proof, not a web
+      page. */
+  coverSeal: {
+    label: 'EMBARGO LIFTED',
+    date: 'IV\u00b726',
+  },
+
+  headline: {
+    prefix: 'The Model',
+    emphasis: 'Picks Up',
+    suffix: 'the Pen.',
+    swash: 'Anthropic opens a design room; we watch the ink spread.',
+  },
+
+  contents: [
+    { n: '001', en: 'The empty canvas closes', jp: '白紙の終焉', tag: 'FIELD' },
+    { n: '002', en: 'A Labs coat, not a hoodie', jp: '実験室の白衣', tag: 'FRAMING' },
+    { n: '003', en: 'Who they brought to the party', jp: '招待された名前', tag: 'PARTNERS' },
+    { n: '004', en: 'Inline comments, meet the prompt', jp: '注釈とプロンプト', tag: 'INTERFACE' },
+    { n: '005', en: 'Figma hears the door', jp: 'フィグマ、扉の音', tag: 'COMPETITION' },
+    { n: '006', en: 'What stays scarce', jp: '残る希少', tag: 'TASTE' },
+    { n: '007', en: 'The only real question', jp: '唯一の問い', tag: 'FUTURE' },
+  ],
+
+  spread: {
+    type: 'dispatch',
+    kicker: 'DISPATCH · 速報',
+    title: 'The Model Picks Up the Pen.',
+    titleJp: 'モデルが筆を持つとき。',
+    deck: 'Seven stakes filed the night Anthropic Labs shipped Claude Design. What just shifted, who should be nervous, what stays scarce, and the only question that still matters by summer.',
+    byline: 'BY THE EDITORS \u00b7 KERNEL.CHAT',
+    stock: 'ivory',
+
+    /** Wire slug — repeats across the top marquee. Reads as
+        newsroom ticker tape. Short, Courier, all caps. */
+    slug: 'KERNEL.CHAT WIRE \u00b7 367 \u00b7 IV\u00b726 \u00b7 FILED 23:47 JST \u00b7 INK WET \u00b7 EMBARGO LIFTED',
+
+    /** Newspaper dateline — read as if spoken by the wire. */
+    dateline: 'SAN FRANCISCO \u2014 APR 17 \u2014 THE EDITORS FILED THIS LATE.',
+
+    /** Dossier stamp fields. */
+    filedAt: '17 APR 2026 \u00b7 23:47 JST',
+    status: 'INK WET',
+
+    /** The partner roll — triangulates the launch audience. */
+    partners: [
+      { name: 'CANVA', role: 'the mass-market channel; half a billion monthly cards.' },
+      { name: 'BRILLIANT', role: 'the learning surface; the next generation of designers discovers the idea here.' },
+      { name: 'DATADOG', role: 'the enterprise column; the line item that pays for the GPUs.' },
+    ],
+
+    /** Bridge to the preceding issue — makes 366 + 367 read as
+        two halves of the same argument. */
+    bridge: {
+      issue: '366',
+      text: '366 watched the tools use us. 367 is the night one of them picked up a pen.',
+    },
+
+    intro: 'Anthropic launched a design product last night. Not a model. Not an API. A tool where you describe what you want, and a model renders it — mockups, prototypes, decks, marketing collateral, code-driven surfaces with voice and shader and 3D. The launch partners were Canva, Brilliant, and Datadog. The framing was "Anthropic Labs," a new division for experimental things. We filed these notes the same night, before the takes industrialised. Some of them will be wrong by June. That is the nature of filing fast.',
+
+    propositions: [
+      {
+        n: '01',
+        overline: 'FIELD',
+        filedAt: '23:12 JST',
+        title: 'The empty canvas is over.',
+        titleJp: '白紙の終焉',
+        body: [
+          'First-draft-for-free arrived for copy in 2023 and for code shortly after. It has now arrived for design. The blank artboard — the scariest hour of the working day, the one where taste is actually formed — has been declared solved by a company that is, on current evidence, good at declaring things solved and then shipping them.',
+          'Whether this is good for designers is a different question from whether it is true. The empty canvas was not only a problem. It was also where the hand learned what the hand wanted to make.',
+        ],
+      },
+      {
+        n: '02',
+        overline: 'FRAMING',
+        filedAt: '23:18 JST',
+        title: 'The Labs coat is not a hoodie.',
+        titleJp: '実験室の白衣',
+        body: [
+          'Anthropic did not launch this as "Claude Design, a new product." They launched it as "Anthropic Labs, which makes experimental things, and here is its first one." The framing is a hedge — Labs can fail; the mainline Claude brand cannot. It is also a commitment. The company that spent three years insisting its model is a tool for thought now has a division whose job is to ship consumer software that looks and feels.',
+          'Watch where the Labs work ends up. The good stuff will be folded into Claude proper within a year. The rest will be quietly retired, and the Labs frame will have absorbed the failure so the brand does not have to.',
+        ],
+      },
+      {
+        n: '03',
+        overline: 'PARTNERS',
+        filedAt: '23:24 JST',
+        title: 'Look at who they brought to the party.',
+        titleJp: '招待された名前',
+        body: [
+          'Canva. Brilliant. Datadog. That triangulation is not accidental. Canva is the mass market — half a billion people who have never opened Figma and make one birthday card a month. Brilliant is the learning channel — the surface where the next generation of designers discovers the idea that "designing" is something a person does. Datadog is the enterprise column, the one whose line item pays for the GPUs.',
+          'Read a launch partner list the way you read a band\u2019s touring cities. It tells you which rooms are being played first, and in what order the rest will follow.',
+        ],
+      },
+      {
+        n: '04',
+        overline: 'INTERFACE',
+        filedAt: '23:31 JST',
+        title: 'Inline comments is a borrowed metaphor.',
+        titleJp: '注釈とプロンプト',
+        body: [
+          'The interface imports a Figma metaphor — comments next to work, custom adjustment controls, a conversational loop — into a place where the work itself is being generated by the same system you are commenting to. This is new. You are no longer a designer commenting on a designer\u2019s draft. You are a reviewer commenting on a reviewer that wrote the draft, will revise the draft based on your comment, and then invite you to comment on the revision.',
+          'The metaphor fits poorly. The product will force the industry to find a new one. The first company to name the interaction well — the right verb for the thing you are doing when you nudge a generated artefact with prose — wins the vocabulary of the next decade of design tools.',
+        ],
+      },
+      {
+        n: '05',
+        overline: 'COMPETITION',
+        filedAt: '23:38 JST',
+        title: 'Figma hears the door.',
+        titleJp: 'フィグマ、扉の音',
+        body: [
+          'If Canva is a public launch partner for Claude Design, Figma is reading the same announcement and running the same arithmetic. The layer of software where "make me a mockup" becomes the default interaction is being restructured in real time, and the company whose entire identity was "we own that layer" has reason to be, quietly, not sleeping well tonight.',
+          'Expect acquisition chatter. Expect pivot rumours. Expect a counter-product announcement before the end of the quarter. The air changed tonight. Whether the ground moves depends on who executes first.',
+        ],
+      },
+      {
+        n: '06',
+        overline: 'TASTE',
+        filedAt: '23:42 JST',
+        title: 'What stays scarce: taste.',
+        titleJp: '残る希少',
+        body: [
+          'First drafts are free. Thousand-draft exploration is free. What is not free — and is getting more valuable by the quarter — is the person who can look at forty generated options and know that thirty-seven are the same idea in different fonts, that two are technically interesting and wrong for this audience, and that the last one, the ugly one, is the one worth pursuing. That is editorial work. No Labs product ships it as a feature.',
+          'The premium on taste just went up, not down. The designers who survive the next two years will be the ones who can say, plainly and without flinching, why one option is better than another. The ones who cannot will be managed by those who can.',
+        ],
+      },
+      {
+        n: '07',
+        overline: 'FUTURE',
+        filedAt: '23:46 JST',
+        title: 'The only real question.',
+        titleJp: '唯一の問い',
+        body: [
+          'Does Claude Design produce outputs designers want to argue with? That is the only question that matters. The outputs you argue with are the ones you keep open and keep changing. The outputs you shrug at are the ones you close the tab on, and the product that produces them gets churned off within ninety days regardless of how impressive the launch partners were.',
+          'We will find out by summer. Until then the pen is in a new hand, the ink is still wet, and the line it draws is the only thing worth watching. Not the press release. The line.',
+        ],
+      },
+    ],
+
+    /** Mid-spread bulletin — the sharpest line lifted out of the
+        propositions and set as a wire billboard. */
+    bulletin: {
+      text: 'The premium on taste just went up, not down.',
+      attribution: 'KERNEL.CHAT \u00b7 DISPATCH \u00b7 367',
+    },
+
+    outro: 'Dispatches get older fast. File this one under APR 2026, next to the take that looked obvious that week and foolish by August. Some of it will hold. The parts that hold are the parts about taste — because taste is always what survives a tool-shift, and there has never been a tool-shift that rewarded the people who did not have any.',
+
+    signoff: '\u8857\u306e\u30b3\u30fc\u30c0\u30fc\u305f\u3061\u3078 \u2014 watch the first marks, not the press release.',
+
+    /** AP-style wire terminator. "— 30 —" closed dispatches on the
+        teletype; the text below is the filing summary. */
+    terminator: 'END OF DISPATCH \u00b7 KERNEL.CHAT/367 \u00b7 FILED 23:47 JST \u00b7 INK STILL WET',
+  },
+
+  credits: {
+    editorInChief: 'Isaac Hernandez',
+    creativeDirection: 'kernel.chat group',
+    artDirection: 'in-house',
+    copy: 'kernel.chat editorial',
+    japanese: 'kernel.chat editorial',
+    production: 'kernel.chat group',
+  },
+}

--- a/src/content/issues/368.ts
+++ b/src/content/issues/368.ts
@@ -1,0 +1,215 @@
+/* ──────────────────────────────────────────────────────────────
+   ISSUE 368 — APRIL 2026
+   THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN
+   モデルが筆を持つ — クロード・デザインについて
+
+   The first dispatch-format issue. 364 was the forecast (general
+   outlook, ink + classic). 366 was the essay (narrative, butter +
+   monument-hero). 367 was the methods-paper essay (ink, asymmetric-
+   left, on behavioral-genetics preselection). 368 introduces a
+   fourth tool: the wire dispatch, filed against a deadline the
+   night a specific event happened — in this case the launch of
+   Anthropic Labs' first product.
+
+   Identity — ivory stock + asymmetric-left layout + ink-spread
+   cover ornament + dispatch spread type. Ivory reads as press-
+   preview white, the paper a launch arrives printed on; the
+   asymmetric-left lockup reads as a bulletin filed on deadline;
+   the tomato ink-spread literalises the swash ("we watch the ink
+   spread"); and the dispatch grammar — wire slug marquee,
+   dateline, dossier card, checkbox numbering, mid-spread
+   bulletin, bridge line to issue 366 — makes the magazine feel
+   serialised rather than episodic. The bridge reaches back to
+   366 (not 367) because 367's topic is orthogonal; 366 → 368
+   is the thematic thread on tools and the people inside them.
+   ────────────────────────────────────────────────────────────── */
+
+import type { IssueRecord } from './index'
+
+export const ISSUE_368: IssueRecord = {
+  number: '368',
+  month: 'APRIL',
+  year: '2026',
+  feature: 'THE MODEL PICKS UP THE PEN: ON ANTHROPIC LABS AND CLAUDE DESIGN',
+  featureJp: 'モデルが筆を持つ — クロード・デザインについて',
+  price: '¥0 · BYOK',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
+
+  /** Cover identity — ivory + asymmetric-left + ink-spread.
+      Combination is unique in the run: ivory has never been
+      paired with an ornament, and the ink-spread ornament is
+      dispatch-exclusive. The result is a cover that reads as a
+      press-preview page with a tomato blot drying in the lower
+      right — a physical object, a bulletin, not UI chrome. */
+  coverStock: 'ivory',
+  coverLayout: 'asymmetric-left',
+  coverOrnament: 'ink-spread',
+
+  /** Press-preview wax seal, top-right corner. Reads as a
+      rubber stamp pressed on the cover before the magazine
+      left the press. Pairs with the ink-spread ornament to
+      make the cover feel like a physical proof, not a web
+      page. */
+  coverSeal: {
+    label: 'EMBARGO LIFTED',
+    date: 'IV\u00b726',
+  },
+
+  headline: {
+    prefix: 'The Model',
+    emphasis: 'Picks Up',
+    suffix: 'the Pen.',
+    swash: 'Anthropic opens a design room; we watch the ink spread.',
+  },
+
+  contents: [
+    { n: '001', en: 'The empty canvas closes', jp: '白紙の終焉', tag: 'FIELD' },
+    { n: '002', en: 'A Labs coat, not a hoodie', jp: '実験室の白衣', tag: 'FRAMING' },
+    { n: '003', en: 'Who they brought to the party', jp: '招待された名前', tag: 'PARTNERS' },
+    { n: '004', en: 'Inline comments, meet the prompt', jp: '注釈とプロンプト', tag: 'INTERFACE' },
+    { n: '005', en: 'Figma hears the door', jp: 'フィグマ、扉の音', tag: 'COMPETITION' },
+    { n: '006', en: 'What stays scarce', jp: '残る希少', tag: 'TASTE' },
+    { n: '007', en: 'The only real question', jp: '唯一の問い', tag: 'FUTURE' },
+  ],
+
+  spread: {
+    type: 'dispatch',
+    kicker: 'DISPATCH · 速報',
+    title: 'The Model Picks Up the Pen.',
+    titleJp: 'モデルが筆を持つとき。',
+    deck: 'Seven stakes filed the night Anthropic Labs shipped Claude Design. What just shifted, who should be nervous, what stays scarce, and the only question that still matters by summer.',
+    byline: 'BY THE EDITORS \u00b7 KERNEL.CHAT',
+    stock: 'ivory',
+
+    /** Wire slug — repeats across the top marquee. Reads as
+        newsroom ticker tape. Short, Courier, all caps. */
+    slug: 'KERNEL.CHAT WIRE \u00b7 368 \u00b7 IV\u00b726 \u00b7 FILED 23:47 JST \u00b7 INK WET \u00b7 EMBARGO LIFTED',
+
+    /** Newspaper dateline — read as if spoken by the wire. */
+    dateline: 'SAN FRANCISCO \u2014 APR 17 \u2014 THE EDITORS FILED THIS LATE.',
+
+    /** Dossier stamp fields. */
+    filedAt: '17 APR 2026 \u00b7 23:47 JST',
+    status: 'INK WET',
+
+    /** The partner roll — triangulates the launch audience. */
+    partners: [
+      { name: 'CANVA', role: 'the mass-market channel; half a billion monthly cards.' },
+      { name: 'BRILLIANT', role: 'the learning surface; the next generation of designers discovers the idea here.' },
+      { name: 'DATADOG', role: 'the enterprise column; the line item that pays for the GPUs.' },
+    ],
+
+    /** Bridge to the preceding issue — makes 366 + 367 read as
+        two halves of the same argument. */
+    bridge: {
+      issue: '366',
+      text: '366 watched the tools use us. 368 is the night one of them picked up a pen.',
+    },
+
+    intro: 'Anthropic launched a design product last night. Not a model. Not an API. A tool where you describe what you want, and a model renders it — mockups, prototypes, decks, marketing collateral, code-driven surfaces with voice and shader and 3D. The launch partners were Canva, Brilliant, and Datadog. The framing was "Anthropic Labs," a new division for experimental things. We filed these notes the same night, before the takes industrialised. Some of them will be wrong by June. That is the nature of filing fast.',
+
+    propositions: [
+      {
+        n: '01',
+        overline: 'FIELD',
+        filedAt: '23:12 JST',
+        title: 'The empty canvas is over.',
+        titleJp: '白紙の終焉',
+        body: [
+          'First-draft-for-free arrived for copy in 2023 and for code shortly after. It has now arrived for design. The blank artboard — the scariest hour of the working day, the one where taste is actually formed — has been declared solved by a company that is, on current evidence, good at declaring things solved and then shipping them.',
+          'Whether this is good for designers is a different question from whether it is true. The empty canvas was not only a problem. It was also where the hand learned what the hand wanted to make.',
+        ],
+      },
+      {
+        n: '02',
+        overline: 'FRAMING',
+        filedAt: '23:18 JST',
+        title: 'The Labs coat is not a hoodie.',
+        titleJp: '実験室の白衣',
+        body: [
+          'Anthropic did not launch this as "Claude Design, a new product." They launched it as "Anthropic Labs, which makes experimental things, and here is its first one." The framing is a hedge — Labs can fail; the mainline Claude brand cannot. It is also a commitment. The company that spent three years insisting its model is a tool for thought now has a division whose job is to ship consumer software that looks and feels.',
+          'Watch where the Labs work ends up. The good stuff will be folded into Claude proper within a year. The rest will be quietly retired, and the Labs frame will have absorbed the failure so the brand does not have to.',
+        ],
+      },
+      {
+        n: '03',
+        overline: 'PARTNERS',
+        filedAt: '23:24 JST',
+        title: 'Look at who they brought to the party.',
+        titleJp: '招待された名前',
+        body: [
+          'Canva. Brilliant. Datadog. That triangulation is not accidental. Canva is the mass market — half a billion people who have never opened Figma and make one birthday card a month. Brilliant is the learning channel — the surface where the next generation of designers discovers the idea that "designing" is something a person does. Datadog is the enterprise column, the one whose line item pays for the GPUs.',
+          'Read a launch partner list the way you read a band\u2019s touring cities. It tells you which rooms are being played first, and in what order the rest will follow.',
+        ],
+      },
+      {
+        n: '04',
+        overline: 'INTERFACE',
+        filedAt: '23:31 JST',
+        title: 'Inline comments is a borrowed metaphor.',
+        titleJp: '注釈とプロンプト',
+        body: [
+          'The interface imports a Figma metaphor — comments next to work, custom adjustment controls, a conversational loop — into a place where the work itself is being generated by the same system you are commenting to. This is new. You are no longer a designer commenting on a designer\u2019s draft. You are a reviewer commenting on a reviewer that wrote the draft, will revise the draft based on your comment, and then invite you to comment on the revision.',
+          'The metaphor fits poorly. The product will force the industry to find a new one. The first company to name the interaction well — the right verb for the thing you are doing when you nudge a generated artefact with prose — wins the vocabulary of the next decade of design tools.',
+        ],
+      },
+      {
+        n: '05',
+        overline: 'COMPETITION',
+        filedAt: '23:38 JST',
+        title: 'Figma hears the door.',
+        titleJp: 'フィグマ、扉の音',
+        body: [
+          'If Canva is a public launch partner for Claude Design, Figma is reading the same announcement and running the same arithmetic. The layer of software where "make me a mockup" becomes the default interaction is being restructured in real time, and the company whose entire identity was "we own that layer" has reason to be, quietly, not sleeping well tonight.',
+          'Expect acquisition chatter. Expect pivot rumours. Expect a counter-product announcement before the end of the quarter. The air changed tonight. Whether the ground moves depends on who executes first.',
+        ],
+      },
+      {
+        n: '06',
+        overline: 'TASTE',
+        filedAt: '23:42 JST',
+        title: 'What stays scarce: taste.',
+        titleJp: '残る希少',
+        body: [
+          'First drafts are free. Thousand-draft exploration is free. What is not free — and is getting more valuable by the quarter — is the person who can look at forty generated options and know that thirty-seven are the same idea in different fonts, that two are technically interesting and wrong for this audience, and that the last one, the ugly one, is the one worth pursuing. That is editorial work. No Labs product ships it as a feature.',
+          'The premium on taste just went up, not down. The designers who survive the next two years will be the ones who can say, plainly and without flinching, why one option is better than another. The ones who cannot will be managed by those who can.',
+        ],
+      },
+      {
+        n: '07',
+        overline: 'FUTURE',
+        filedAt: '23:46 JST',
+        title: 'The only real question.',
+        titleJp: '唯一の問い',
+        body: [
+          'Does Claude Design produce outputs designers want to argue with? That is the only question that matters. The outputs you argue with are the ones you keep open and keep changing. The outputs you shrug at are the ones you close the tab on, and the product that produces them gets churned off within ninety days regardless of how impressive the launch partners were.',
+          'We will find out by summer. Until then the pen is in a new hand, the ink is still wet, and the line it draws is the only thing worth watching. Not the press release. The line.',
+        ],
+      },
+    ],
+
+    /** Mid-spread bulletin — the sharpest line lifted out of the
+        propositions and set as a wire billboard. */
+    bulletin: {
+      text: 'The premium on taste just went up, not down.',
+      attribution: 'KERNEL.CHAT \u00b7 DISPATCH \u00b7 368',
+    },
+
+    outro: 'Dispatches get older fast. File this one under APR 2026, next to the take that looked obvious that week and foolish by August. Some of it will hold. The parts that hold are the parts about taste — because taste is always what survives a tool-shift, and there has never been a tool-shift that rewarded the people who did not have any.',
+
+    signoff: '\u8857\u306e\u30b3\u30fc\u30c0\u30fc\u305f\u3061\u3078 \u2014 watch the first marks, not the press release.',
+
+    /** AP-style wire terminator. "— 30 —" closed dispatches on the
+        teletype; the text below is the filing summary. */
+    terminator: 'END OF DISPATCH \u00b7 KERNEL.CHAT/368 \u00b7 FILED 23:47 JST \u00b7 INK STILL WET',
+  },
+
+  credits: {
+    editorInChief: 'Isaac Hernandez',
+    creativeDirection: 'kernel.chat group',
+    artDirection: 'in-house',
+    copy: 'kernel.chat editorial',
+    japanese: 'kernel.chat editorial',
+    production: 'kernel.chat group',
+  },
+}

--- a/src/content/issues/PUBLISHING.md
+++ b/src/content/issues/PUBLISHING.md
@@ -1,0 +1,315 @@
+# Publishing a new issue of kernel.chat
+
+> **READ ME FIRST** if you are asked to "write the next issue", "make an
+> issue about X", "ship a new issue", "publish a new drop", etc.
+>
+> This file is the single source of truth for the publishing workflow.
+> It is loaded from `src/content/issues/` so it lives next to the work.
+
+---
+
+## I. What kernel.chat is
+
+kernel.chat is an **editorial magazine**, not an app. Every drop is
+`ISSUE N · MONTH YEAR`. The publication voice is POPEYE-inspired:
+warm paper stocks, a single tomato spot color, EB Garamond + Courier
+Prime, bilingual JP/Latin lockups, numbered catalogs, a monument
+number, a MagazineFrame wrapper.
+
+**Never name the inspiration on the site.** No "POPEYE" in user-visible
+copy. The grammar carries the homage.
+
+Magazine vocabulary (issue, feature, spread, folio, kicker, monument,
+colophon, masthead, dateline, bulletin) — not app vocabulary
+(dashboard, panel, card, widget, modal).
+
+---
+
+## II. Where issues live
+
+```
+src/content/issues/
+├── index.ts         ← the archive + all type definitions
+├── 360.ts ... 368.ts ← frozen snapshots, one per issue
+└── PUBLISHING.md    ← this file
+```
+
+Cover and spread rendering:
+
+```
+src/components/
+├── IssueCover.tsx        ← cover (used on landing + permanent URL)
+├── IssueFeature.tsx      ← router: dispatches to the right spread type
+├── EssayFeature.{tsx,css}
+├── InterviewFeature.{tsx,css}
+├── ForecastFeature.{tsx,css}
+└── DispatchFeature.{tsx,css}
+```
+
+Cover layout CSS lives in `src/pages/LandingPage.css` — the
+`.pop-cover`, `.pop-cover--classic`, `.pop-cover--monument-hero`,
+`.pop-cover--asymmetric-left`, and ornament/seal rules are all there.
+
+---
+
+## III. Deciding the next issue's identity
+
+Before touching code, answer these five questions. They determine the
+issue's entire visual grammar. **No two recent issues should share all
+five answers** — that is how we keep each cover feeling like its own
+object.
+
+### 1. What number?
+
+Always one more than `LATEST_ISSUE` in `src/content/issues/index.ts`.
+If another branch is also drafting the next issue, check git:
+
+```bash
+git log --all --oneline --grep="ISSUE $((N+1))\|ISSUE $((N+2))"
+```
+
+If a collision exists, **renumber to the next free slot** rather than
+fighting over the number. Both issues can ship — see §VII.
+
+### 2. What format? (`spread.type`)
+
+Pick the editorial tool that fits the content:
+
+| Type | Used for | Visual grammar |
+|---|---|---|
+| `essay` | Culture, style, long-form observation | Drop cap, section kickers, pull quote. Optional: dossier / dataBlock / references modules |
+| `interview` | Profiles of people (real, fictional, composite) | Subject dossier + Q&A exchanges |
+| `forecast` | Manifestos, predictions, numbered declarations | Tomato ring badges + bold titles + prose body |
+| `dispatch` | News reactions filed against a deadline | Wire slug marquee, dateline, dossier card, checkbox numbering, mid-spread bulletin, bridge line, `— 30 —` terminator |
+
+If none fit, **add a new spread type** — don't force a format. See §V.
+
+### 3. What paper stock? (`coverStock`)
+
+Five options: `cream` · `butter` · `kraft` · `ivory` · `ink`
+
+Pick the one whose material quality reinforces the topic. Cream is the
+default; butter is lamplight-warm; kraft is fashion/field-report;
+ivory is lab-bench or press-preview white; ink is manifesto / archival
+/ nocturnal.
+
+### 4. What cover layout? (`coverLayout`)
+
+Three options:
+
+- `classic` — centered, monument bottom-right (default)
+- `monument-hero` — issue number IS the cover art, headline shrinks (use when the number is thematic: anniversary, absence, milestone)
+- `asymmetric-left` — left-aligned lockup, editorial-column rhythm (fashion, culture, dispatch)
+
+### 5. What signature move? (optional but preferred)
+
+One distinctive element that makes THIS cover recognizable at a glance.
+Examples in use:
+
+- **coverOrnament: 'ink-spread'** — tomato blot bleeding off the corner (368)
+- **coverSeal: { label, date }** — circular rubber-stamp in top-right (368)
+
+New ornaments live as new members of the `IssueCoverOrnament` union
+in `index.ts`; new seals reuse the existing component.
+
+Propose new ones when the topic calls for them — these are meant to
+grow with the archive.
+
+---
+
+## IV. Writing the issue file
+
+Create `src/content/issues/<N>.ts` following the shape of the most
+recent same-format issue (`367.ts` for essay, `368.ts` for dispatch,
+etc.). Every issue needs:
+
+- A leading block comment explaining the identity decisions
+- `number`, `month`, `year`, `feature`, `featureJp`, `price`, `tagline`
+- `coverStock`, `coverLayout`, optional `coverOrnament`, `coverSeal`
+- `headline` — `{ prefix, emphasis, suffix, swash }` — the emphasis is
+  the loudest italic-tomato word on the cover
+- `contents` — numbered catalog items with EN + JP + TAG
+- `spread` — the editorial body
+- `credits` — the masthead
+
+Then register in `index.ts`:
+
+1. Add `import { ISSUE_<N> } from './<N>'`
+2. Push `ISSUE_<N>` onto `ALL_ISSUES` (order matters — oldest first)
+3. `LATEST_ISSUE` automatically flips to the new cover
+
+### Voice
+
+Write like the magazine. Match the existing cadence:
+
+- EB Garamond for prose, Courier Prime for metadata
+- Short sentences next to long ones
+- Declarations, then caveats
+- Japanese subtitles for structural elements (title, contents, section
+  headings, kicker). Use real Japanese, not machine glosses — ask if
+  unsure rather than inventing
+- Em-dashes, not hyphens or parentheses, for asides
+- Cite companies/products explicitly when the issue is about them
+  (dispatch partners) — but keep the cover headline editorial, not
+  news-feed
+
+### Signoff
+
+Every spread ends with a signoff line, usually beginning
+`街のコーダーたちへ` ("for the city coders") followed by an em-dash
+and a short imperative.
+
+---
+
+## V. Adding a new editorial tool
+
+When no existing spread type fits, add one. The pattern:
+
+1. **Extend the discriminated union** in `src/content/issues/index.ts`:
+   ```ts
+   export interface RecipeSpread extends SpreadCommon {
+     type: 'recipe'
+     // ... fields
+   }
+   export type IssueSpread = EssaySpread | InterviewSpread | ForecastSpread | DispatchSpread | RecipeSpread
+   ```
+
+2. **Build the component**: `src/components/RecipeFeature.{tsx,css}` —
+   copy the structure of the closest existing feature, replace the
+   body rendering.
+
+3. **Register in the router**: add a `case 'recipe':` in
+   `src/components/IssueFeature.tsx`. TypeScript will flag missing
+   cases via the exhaustiveness check at the bottom of the switch.
+
+4. **Document the new type** in §III above (this file).
+
+Keep new types orthogonal — don't extend existing ones unless the new
+field is genuinely optional for every existing issue of that type.
+
+---
+
+## VI. Verifying before shipping
+
+Always run all three:
+
+```bash
+npx tsc --noEmit         # type-check — MUST be clean
+npm run build            # vite build — MUST be clean
+```
+
+Then preview the new issue visually:
+
+```bash
+npm run dev              # starts at localhost:5173
+```
+
+Browse:
+- `/` — the landing, should show the new cover as `LATEST_ISSUE`
+- `/issues/<N>` — the permanent URL for this issue
+- `/issues/<N-1>` — the prior issue, which now shows as `PREVIOUSLY`
+- Check mobile breakpoint (≤640px) — the cover should still read
+
+---
+
+## VII. Publishing
+
+```bash
+npm run deploy           # build + force-push dist/ to gh-pages
+```
+
+The `deploy` script in `package.json` does the heavy lifting:
+
+1. `tsc && vite build` (via the `build` script prerequisite — run it
+   explicitly first if you want to see build output separately)
+2. `cd dist && git init`
+3. Force-push `dist/` to the `gh-pages` branch at
+   `https://github.com/isaacsight/kernel.git`
+
+The live site (`https://kernel.chat`) serves from gh-pages via
+GitHub Pages + Cloudflare. Deploys propagate within ~30 seconds.
+
+### If your branch is NOT main
+
+**Important:** `gh-pages` does not care which source branch you deploy
+from — it builds the current worktree and pushes `dist/` to gh-pages.
+That means a deploy from a feature branch will make your changes
+visible on kernel.chat, **but a subsequent deploy from `main` will
+overwrite them**.
+
+Always: **merge to main before (or immediately after) deploying.**
+
+### Collision: another branch also drafted this issue number
+
+Both issues can ship. Renumber the later one to the next free slot
+and pull the earlier one into your branch:
+
+```bash
+# Find the other branch's commit
+git log --all --oneline --grep="ISSUE <N>"
+
+# Rename yours to <N+1>
+git mv src/content/issues/<N>.ts src/content/issues/<N+1>.ts
+# (then update ISSUE_<N> → ISSUE_<N+1> constant, number field,
+#  and any hardcoded number in slug/bulletin/terminator strings)
+
+# Pull the other branch's issue file into your branch
+git show <other-sha>:src/content/issues/<N>.ts > src/content/issues/<N>.ts
+
+# If the other branch added new type definitions or component
+# updates (e.g. new EssaySpread modules), pull those too:
+git show <other-sha>:src/components/<Component>.tsx > src/components/<Component>.tsx
+
+# Register both in index.ts, typecheck, build, deploy
+```
+
+---
+
+## VIII. Writing the commit message
+
+Match the existing style — title line is `ISSUE <N> — <TITLE>`,
+followed by a 2–3 paragraph body explaining identity decisions and
+any new types / components introduced.
+
+Always include:
+
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## IX. After publishing
+
+- Update `SCRATCHPAD.md` with what shipped
+- If a new spread type was added, update `docs/design-language.md`
+  (if it exists and documents the current spread types)
+- If the user asked for it, post to socials via `kbot_social` MCP
+  tools — otherwise don't
+
+---
+
+## X. Recipes for common asks
+
+### "Make the next issue about X"
+
+1. Read X (WebFetch if it's a URL, otherwise ask for source material)
+2. Decide identity per §III — pick format, stock, layout, signature move
+3. Create `<N>.ts` using the most relevant existing issue as a template
+4. Register in `index.ts`
+5. Typecheck → build → preview → deploy
+
+### "Give this issue more character"
+
+Propose the signature move first (§III.5). Then, if the user agrees,
+either reuse an existing ornament/seal or propose a new `spread.type`
+extension. Keep new editorial tools to issues that genuinely need them
+— this is a magazine, not a pattern library.
+
+### "Ship it"
+
+Typecheck → build → commit on the current branch with the format in §VIII → `npm run deploy`. Then flag whether the branch needs merging to main.
+
+---
+
+_Last updated: ISSUE 368 · APR 2026._

--- a/src/content/issues/index.ts
+++ b/src/content/issues/index.ts
@@ -19,6 +19,7 @@ import { ISSUE_363 } from './363'
 import { ISSUE_364 } from './364'
 import { ISSUE_365 } from './365'
 import { ISSUE_366 } from './366'
+import { ISSUE_367 } from './367'
 
 export interface ContentsItem {
   /** Numbered catalog number, padded (e.g. "001") */
@@ -151,8 +152,100 @@ export interface ForecastSpread extends SpreadCommon {
   outro?: string
 }
 
+/** ─── dispatch ────────────────────────────────────────────────
+ *  A wire-style news dispatch — numbered stakes filed against a
+ *  deadline, the night a specific event happened. Forecast is
+ *  general outlook; dispatch is reactive and dated. The grammar
+ *  is borrowed from the newswire: a repeating wire-slug band at
+ *  the top, a proper dateline, a dossier card with FILED / STATUS
+ *  / PARTNERS, checkbox-numbered items (things verified before
+ *  filing, not declarations from on high), a mid-spread bulletin
+ *  pull-quote, and an optional bridge sentence that links the
+ *  dispatch to the preceding issue so the magazine reads as a
+ *  running serial. */
+export interface DispatchPartner {
+  /** Partner name, uppercase (e.g. "CANVA"). */
+  name: string
+  /** One-line role / reason they appear in the roll. */
+  role: string
+}
+
+export interface DispatchProposition {
+  /** Catalog number, padded — "01", "02", etc. */
+  n: string
+  /** Short declaration — one sentence, bold serif. */
+  title: string
+  /** Japanese subtitle for the proposition. */
+  titleJp?: string
+  /** Prose explanation, 1–3 short paragraphs. */
+  body: string[]
+  /** Optional Courier overline tag above the title — pulls the
+   *  matching CONTENTS tag into the body (e.g. "FIELD", "TASTE").
+   *  Ties the back-of-book catalog to the prose. */
+  overline?: string
+  /** Optional wire-style timestamp rendered in a thin Courier
+   *  rail to the left of the item on desktop (e.g. "23:47 JST").
+   *  Hidden on mobile — the rail is a desktop-only flourish. */
+  filedAt?: string
+}
+
+export interface DispatchBulletin {
+  /** The single loudest line lifted out of the propositions.
+   *  Rendered as an em-dashed wire bulletin callout mid-spread. */
+  text: string
+  /** Optional attribution under the bulletin. */
+  attribution?: string
+}
+
+export interface DispatchBridge {
+  /** Issue number referenced (e.g. "366"). */
+  issue: string
+  /** Italic bridge sentence connecting this dispatch to that
+   *  issue, printed at the top of the spread — makes the mag
+   *  read as a continuing serial rather than episodic. */
+  text: string
+}
+
+export interface DispatchSpread extends SpreadCommon {
+  type: 'dispatch'
+  /** Repeating wire-slug band (Courier mono marquee at top). */
+  slug: string
+  /** Newspaper dateline, e.g. "SAN FRANCISCO — APR 17 — ..." */
+  dateline: string
+  /** Filed-at stamp shown in the dossier card. */
+  filedAt: string
+  /** Status stamp — "WET", "FILED", "EMBARGO LIFTED", etc. */
+  status: string
+  /** Partners / players attached to the story. Rendered as a
+   *  numbered sample card inset into the spread. */
+  partners?: DispatchPartner[]
+  /** Editorial bridge to an adjacent issue. */
+  bridge?: DispatchBridge
+  /** Standfirst prose block before the first proposition. */
+  intro?: string
+  /** Numbered stakes. Rendered with checkbox numbering —
+   *  hollow tomato squares with a hand-stroked check inside —
+   *  to read as "verified before filing" rather than forecast
+   *  circles reading as "declared from on high". */
+  propositions: DispatchProposition[]
+  /** Mid-spread wire bulletin — a single sharp line lifted
+   *  out of the propositions and set as a billboard. */
+  bulletin?: DispatchBulletin
+  /** Closing paragraph after the last proposition. */
+  outro?: string
+  /** Wire terminator — the `— 30 —` line that closed old AP
+   *  dispatches, rendered as a single Courier rule at the very
+   *  end of the spread. Optional; when omitted, the dispatch
+   *  closes with the signoff and monument. */
+  terminator?: string
+}
+
 /** Discriminated union — add new editorial tools here. */
-export type IssueSpread = EssaySpread | InterviewSpread | ForecastSpread
+export type IssueSpread =
+  | EssaySpread
+  | InterviewSpread
+  | ForecastSpread
+  | DispatchSpread
 
 export interface IssueCredits {
   editorInChief: string
@@ -183,6 +276,29 @@ export type IssueStock = 'cream' | 'butter' | 'kraft' | 'ivory' | 'ink'
  */
 export type IssueCoverLayout = 'classic' | 'monument-hero' | 'asymmetric-left'
 
+/**
+ * Optional cover ornament — a decorative mark that reinforces
+ * the issue's theme. Currently:
+ *
+ * - 'ink-spread' — a tomato ink blot bleeding off the lower-right
+ *                  margin of the cover. Pairs with dispatch-style
+ *                  issues whose swash names the ink literally.
+ *
+ * Most issues do not set this; leaving it undefined is the default.
+ */
+export type IssueCoverOrnament = 'ink-spread'
+
+/** Optional press-preview wax seal rendered in the top-right
+ *  corner of the cover. Reads as a rubber stamp or embargo seal;
+ *  pairs naturally with dispatch issues but can be used on any
+ *  cover where a one-line stamp adds editorial weight. */
+export interface IssueCoverSeal {
+  /** Upper arc label, e.g. "EMBARGO LIFTED". */
+  label: string
+  /** Center-bottom date, e.g. "IV·26". */
+  date: string
+}
+
 export interface IssueRecord {
   number: string
   month: string
@@ -197,6 +313,13 @@ export interface IssueRecord {
   coverStock?: IssueStock
   /** Cover composition variant. Defaults to 'classic'. */
   coverLayout?: IssueCoverLayout
+  /** Optional decorative cover ornament. Set per-issue; most
+   *  issues omit it. */
+  coverOrnament?: IssueCoverOrnament
+  /** Optional press-preview wax seal in the cover's top-right
+   *  corner. Orthogonal to the ornament — issues can use both,
+   *  either, or neither. */
+  coverSeal?: IssueCoverSeal
   /** Optional long-form editorial feature (prose, no images). */
   spread?: IssueSpread
   /** Optional masthead / editorial team credits. */
@@ -212,6 +335,7 @@ export const ALL_ISSUES: IssueRecord[] = [
   ISSUE_364,
   ISSUE_365,
   ISSUE_366,
+  ISSUE_367,
 ]
 
 /** The latest published issue — drives the landing cover. */

--- a/src/content/issues/index.ts
+++ b/src/content/issues/index.ts
@@ -20,6 +20,7 @@ import { ISSUE_364 } from './364'
 import { ISSUE_365 } from './365'
 import { ISSUE_366 } from './366'
 import { ISSUE_367 } from './367'
+import { ISSUE_368 } from './368'
 
 export interface ContentsItem {
   /** Numbered catalog number, padded (e.g. "001") */
@@ -94,13 +95,77 @@ export interface SpreadPullQuote {
   attribution: string
 }
 
+/** A labeled data row for the abstract dossier at the top of an
+ *  essay — reads like the front matter of a methods paper. */
+export interface SpreadDossierItem {
+  label: string
+  labelJp?: string
+  value: string
+  valueJp?: string
+}
+
+/** A methods-paper-style abstract block that can sit above the
+ *  essay body — mono labels, tomato values, numbered rows. */
+export interface SpreadDossier {
+  kicker: string
+  note?: string
+  items: SpreadDossierItem[]
+}
+
+/** A single statistic in a "by the numbers" data block —
+ *  large tomato display type, caption underneath. */
+export interface SpreadStat {
+  n: string
+  label: string
+  labelJp?: string
+  source?: string
+}
+
+/** A mid-essay data block. Interrupts the prose rhythm with a
+ *  grid of large statistics. `afterSection` is the 0-indexed
+ *  position where the block should appear (inserts *after* that
+ *  section). */
+export interface SpreadDataBlock {
+  kicker: string
+  heading?: string
+  headingJp?: string
+  afterSection: number
+  stats: SpreadStat[]
+}
+
+/** A single cited work for the works-cited block. Mono type,
+ *  hanging-indent layout. */
+export interface SpreadReference {
+  authors: string
+  year: string
+  title: string
+  journal?: string
+}
+
+/** The works-cited block at the foot of the essay. Gives an
+ *  editorial essay the weight of a methods paper when the topic
+ *  calls for it. */
+export interface SpreadReferences {
+  kicker: string
+  note?: string
+  items: SpreadReference[]
+}
+
 /** ─── essay ────────────────────────────────────────────────────
  *  Long-form prose with drop cap, section kickers, pull quote.
- *  Used for culture / style / field-of-thought features. */
+ *  Used for culture / style / field-of-thought features.
+ *
+ *  Optional modules for issues that want more expression:
+ *  - dossier:    abstract block at the top (methods-paper card)
+ *  - dataBlock:  "by the numbers" grid inserted between sections
+ *  - references: works-cited block at the foot */
 export interface EssaySpread extends SpreadCommon {
   type: 'essay'
   sections: SpreadSection[]
   pullQuote?: SpreadPullQuote
+  dossier?: SpreadDossier
+  dataBlock?: SpreadDataBlock
+  references?: SpreadReferences
 }
 
 /** ─── interview ────────────────────────────────────────────────
@@ -336,6 +401,7 @@ export const ALL_ISSUES: IssueRecord[] = [
   ISSUE_365,
   ISSUE_366,
   ISSUE_367,
+  ISSUE_368,
 ]
 
 /** The latest published issue — drives the landing cover. */

--- a/src/pages/LandingPage.css
+++ b/src/pages/LandingPage.css
@@ -805,3 +805,127 @@
     align-items: flex-start;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────
+   Cover ornaments — optional decorative marks that reinforce the
+   issue's theme. One ornament per issue, set via
+   IssueRecord.coverOrnament. Kept scoped to the pop-cover so the
+   positioning context (relative) is guaranteed.
+   ────────────────────────────────────────────────────────────── */
+
+/* When an ornament is present, clip it to the cover's edge so it
+   bleeds off-page rather than overflowing the next section. */
+.pop-cover[class*="pop-cover--ornament-"] {
+  overflow: hidden;
+}
+
+.pop-cover-ornament {
+  position: absolute;
+  pointer-events: none;
+  color: var(--pop-tomato);
+  z-index: 0;
+}
+
+/* The .pop-cover-inner sits on z-index 1 so the ornament reads as
+   a ground layer — ink drying under the typography, not over it. */
+.pop-cover[class*="pop-cover--ornament-"] .pop-cover-inner {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── ink-spread — tomato blot bleeding off the lower-right
+      corner. Sized and offset so only ~40% of the blot appears
+      on-page; it reads as ink that ran off the press before the
+      cover was trimmed. Mix-blend-multiply fuses it into the
+      paper stock. Kept small enough that it never overlaps the
+      monument text on the asymmetric-left layout. */
+.pop-cover-ornament--ink-spread {
+  right: clamp(-180px, -12vw, -120px);
+  bottom: clamp(-120px, -8vw, -80px);
+  width: clamp(200px, 26vw, 340px);
+  height: auto;
+  opacity: 0.75;
+  mix-blend-mode: multiply;
+  transform: rotate(8deg);
+}
+
+/* On ink stock the blot would disappear — re-mode it to screen. */
+.pop-stock-ink .pop-cover-ornament--ink-spread {
+  mix-blend-mode: normal;
+  opacity: 0.22;
+}
+
+@media (max-width: 640px) {
+  .pop-cover-ornament--ink-spread {
+    width: 160px;
+    right: -60px;
+    bottom: -40px;
+    opacity: 0.65;
+  }
+}
+
+/* When the ink-spread ornament is active, flip the monument's
+   tomato issue-number to ink so it doesn't disappear against
+   the blot. Dark serif numeral reads clearly on both the ivory
+   paper ground AND the tomato blot where they overlap. */
+.pop-cover--ornament-ink-spread .pop-monument strong {
+  color: var(--pop-ink);
+}
+
+/* ──────────────────────────────────────────────────────────────
+   Cover seal — press-preview rubber stamp in the top-right
+   corner. Tomato outline, curved label, Courier date, five-point
+   star anchor. Slight tilt so it reads as hand-stamped, not
+   printed. Full-width on mobile so it stays visible.
+   ────────────────────────────────────────────────────────────── */
+
+.pop-cover--has-seal {
+  position: relative;
+}
+
+.pop-cover-seal {
+  position: absolute;
+  top: 72px;
+  right: 48px;
+  width: clamp(84px, 9vw, 120px);
+  height: auto;
+  aspect-ratio: 1;
+  color: var(--pop-tomato);
+  transform: rotate(-8deg);
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0.92;
+}
+
+.pop-cover-seal-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.pop-cover-seal-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.pop-cover-seal-date {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 640px) {
+  .pop-cover-seal {
+    top: 24px;
+    right: 18px;
+    width: 76px;
+    transform: rotate(-6deg);
+  }
+  .pop-cover-seal-label { font-size: 8px; letter-spacing: 0.18em; }
+  .pop-cover-seal-date { font-size: 12px; }
+}


### PR DESCRIPTION
## Summary

- **ISSUE 367 · The Sieve: On Preselection in Behavioral Genetics** — 8-section methods-paper essay on ink paper, asymmetric-left. Extends `EssaySpread` with three optional modules: `dossier` (methods-paper front matter), `dataBlock` (Harper's-Index statistic grid), `references` (works-cited footer).
- **ISSUE 368 · The Model Picks Up the Pen: On Anthropic Labs and Claude Design** — news-reaction drop, filed the night of the Claude Design launch. Introduces the new `dispatch` spread type with 11 distinct visual moves: wire-slug marquee, newspaper dateline, rotated gummed dossier card with `STATUS INK WET` stamp, partner roll, checkbox proposition numbering, proposition overlines, left-rail filed-at timestamps, mid-spread `BULLETIN` callout, bridge line to issue 366, `— 30 —` wire terminator. Cover: ivory stock + asymmetric-left + tomato ink-spread ornament + `EMBARGO LIFTED` press seal.
- **`src/content/issues/PUBLISHING.md`** — single source of truth for the magazine workflow: identity decisions, spread types, collision handling, deploy steps. CLAUDE.md header now points at it so future sessions discover it automatically.

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean (73 precache entries)
- [ ] Landing shows ISSUE 368 as `LATEST_ISSUE`
- [ ] `/issues/367` shows The Sieve with essay + dossier + dataBlock + references
- [ ] `/issues/368` shows The Model Picks Up the Pen with full dispatch grammar
- [ ] PREVIOUSLY on 368 links to 367; PREVIOUSLY on 367 links to 366
- [ ] Mobile layout (≤640px) keeps both covers legible and the dispatch dossier card readable
- [ ] Already deployed to `gh-pages`; live at https://kernel.chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)