### PR TITLE
system-glyph: ratify the asterisk (★) as the kernel.chat folio mark

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -211,6 +211,41 @@ issue variants):
 
 Nothing else. No system fonts, no sans-serif.
 
+### System glyph — the kernel.chat folio mark
+
+**The asterisk (★)** — ratified ISSUE 370 — is the magazine's
+single recurring small mark, threaded through every folio strip in
+the system. Borrowed practice from PAPERSKY (whose paper-airplane
+glyph plays the same role), implemented through the existing
+`<PopIcon name="asterisk">` SVG and the `.pop-system-glyph` CSS
+class in `src/index.css`.
+
+**Where it appears** (one place per surface — never as decoration):
+
+| Surface | Position | Component |
+|---|---|---|
+| Cover dateline | Leading the issue folio (top-right of every cover) | `IssueCover.tsx` |
+| Frame masthead | Leading the issue folio (top of every inner page) | `MagazineFrame.tsx` |
+| Frame footer | Leading the issue folio (bottom of every inner page) | `MagazineFrame.tsx` |
+
+**Spec**: tomato spot color, `0.85em` of the surrounding folio
+text, vertically centred, `6px` right margin, `opacity: 0.95`.
+Renders the existing `PopIcon` `asterisk` stroke SVG — no new
+infrastructure.
+
+**Discipline**: this is the **only** small graphic mark that
+travels through the system. The rest of the `<PopIcon>` vocabulary
+(`leaf`, `coffee`, `pin`, `quote`, `thread`, etc.) remains
+available for *single-use editorial accents* inside specific
+issues, but none of them are systemwide. A system with eleven
+small marks has none. We have one. Keep it.
+
+**Promotion path** for future surfaces: section openers
+(`pop-section-header`), page-number folios on long features,
+colophon. Add only if the surface already carries the issue meta
+strip — otherwise the asterisk reads as decoration, not as a
+thread.
+
 ### Primitives (`src/index.css:29320+`)
 
 | Primitive | What it is | Where it appears |

--- a/src/components/IssueCover.tsx
+++ b/src/components/IssueCover.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import type { IssueRecord } from '../content/issues'
+import { PopIcon } from './ornaments'
 
 interface IssueCoverProps {
   /** The issue being rendered. Used for both content (number, month,
@@ -59,7 +60,10 @@ export function IssueCover({ issue, footer }: IssueCoverProps) {
               <span className="pop-marquee-item">都会に住んで、コードで遊ぶための、自由なスタイルを作ろう。</span>
             </span>
           </span>
-          <span className="pop-folio">ISSUE {issue.number} · {issue.month} {issue.year}</span>
+          <span className="pop-folio">
+            <PopIcon name="asterisk" size="sm" className="pop-system-glyph" />
+            ISSUE {issue.number} · {issue.month} {issue.year}
+          </span>
         </div>
 
         <hr className="pop-rule" />

--- a/src/components/MagazineFrame.tsx
+++ b/src/components/MagazineFrame.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { ISSUE } from '../content/issue'
 import type { IssueRecord } from '../content/issues'
+import { PopIcon } from './ornaments'
 import './MagazineFrame.css'
 
 interface MagazineFrameProps {
@@ -76,6 +77,7 @@ export function MagazineFrame({
             </button>
             <div className="pop-frame-issue">
               <span className="pop-folio">
+                <PopIcon name="asterisk" size="sm" className="pop-system-glyph" />
                 ISSUE {issue.number} · {issue.month} {issue.year}
               </span>
               <span className="pop-folio pop-frame-folio">{folio}</span>
@@ -121,6 +123,7 @@ export function MagazineFrame({
               </a>
             </div>
             <span className="pop-folio">
+              <PopIcon name="asterisk" size="sm" className="pop-system-glyph" />
               ISSUE {ISSUE.number} · {ISSUE.month} {ISSUE.year}
             </span>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -29405,6 +29405,16 @@ h4 {
 /* Folio — page number, byline, date in corners */
 .pop-folio { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--letter-spacing-caps); text-transform: uppercase; color: var(--pop-ink); opacity: 0.7; }
 
+/* System glyph — the kernel.chat folio mark.
+   Ratified ISSUE 370 as the magazine's single recurring small mark
+   (per docs/design-language.md, Editorial Neighbours → PAPERSKY).
+   One mark, used everywhere a folio appears: cover dateline, frame
+   masthead, frame footer. Tomato spot, vertically aligned with the
+   adjacent mono folio text, sized down so it punctuates rather than
+   announces. Renders the existing PopIcon `asterisk` SVG. */
+.pop-system-glyph { display: inline-flex; vertical-align: middle; align-items: center; color: var(--pop-tomato); margin-right: 6px; opacity: 0.95; }
+.pop-system-glyph .pop-icon-svg { width: 0.85em; height: 0.85em; }
+
 /* Marquee — horizontal ticker, magazine-style.
    Used for the cover dateline JP tagline. Drifts at ~4px/second.
    Duplicated content + translate loop so there is no visible seam.


### PR DESCRIPTION
## Summary

Auditioned on the ISSUE 370 cover (kicker + signoff). Promoted now to a system-wide thread per the editorial-neighbours practice merged in #37 — the **single-glyph system thread** ★ mechanic from PAPERSKY, applied to kernel.chat.

The asterisk now appears as a leading mark on the issue folio at three system positions, threading through every cover and every inner page:

| Surface | Position | File |
|---|---|---|
| Cover dateline | Leading the issue folio (top-right of every cover) | `IssueCover.tsx` |
| Frame masthead | Leading the issue folio (top of every inner page) | `MagazineFrame.tsx` |
| Frame footer | Leading the issue folio (bottom of every inner page) | `MagazineFrame.tsx` |

Implementation reuses the existing `<PopIcon name="asterisk">` stroke SVG — no new component. New CSS class `.pop-system-glyph` in `src/index.css` locks the spec: tomato spot, `0.85em` of the surrounding folio text, vertically centred, `6px` right margin, `opacity: 0.95`.

`docs/design-language.md` gains a **System glyph — the kernel.chat folio mark** subsection declaring the asterisk canonical, naming the discipline (one mark, never eleven), and noting the promotion path for future surfaces (section openers, page-number folios, colophon).

## Status of the four ★ PAPERSKY mechanics

| Mechanic | Status |
|---|---|
| **Restraint** | Cashed in on the ISSUE 370 cover (cream + monument-hero + no ornament + small seal). |
| **Single-glyph system thread** | **This PR.** ★ now threads every folio strip system-wide. |
| **Place-and-route** | Authorial discipline; already in use (369's NPR → Pietsch → Shedd; 370's seven-step route). No code change needed. |
| **Postmark dateline** | Held back for a future issue whose subject calls for geographic grounding rather than serial-position grounding. |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Visual: open `/` — every issue cover (360–370) shows ★ leading the issue folio in the dateline
- [ ] Visual: open any inner route (`/security`, `/bench`, `/privacy`, `/terms`, `/issues/369`, `/issues/370`) — ★ shows in the masthead AND footer issue-folio strip
- [ ] Mobile (≤640px): glyph stays vertically centred with the folio text and doesn't break wrapping
- [ ] Print stylesheet: glyph either renders in tomato press spot or hides cleanly (acceptable either way; verify it doesn't print as a noisy SVG block)

https://claude.ai/code/session_01AvTucQFfKbumzeJR2RPXU3