### PR TITLE
ISSUE 370 — cover emphasis: Finding → Found

### DIFF
--- a/src/content/issues/370.ts
+++ b/src/content/issues/370.ts
@@ -73,9 +73,9 @@ export const ISSUE_370: IssueRecord = {
   },
 
   headline: {
-    prefix: 'On',
-    emphasis: 'Finding',
-    suffix: 'a Design Language.',
+    prefix: 'A Design Language is',
+    emphasis: 'Found',
+    suffix: ', not Designed.',
     swash: 'Seven stakes for 2027, drawn from the magazines on the shelf.',
   },
 


### PR DESCRIPTION
## Summary

Shift ISSUE 370's cover headline from "On *Finding* a Design Language." to "A Design Language is *Found*, not Designed." so the cover states the spread's core claim — the intro's thesis that "the agreement is *found*, not designed" — instead of just naming the topic.

Pure typographic move. No new marks, no new ornaments. The quiet cover (stake #6) stays quiet; FOUND carries the tomato italic in place of FINDING, tightening the cover-to-prose match without breaking the restraint thesis.

## Test plan

- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run dev` → visit `/` — new cover reads "A Design Language is *Found*, not Designed."
- [ ] Visit `/issues/370` — permanent URL renders the same
- [ ] Mobile breakpoint (≤640px) — cover still reads cleanly
- [ ] Merge to main before running `npm run deploy`

https://claude.ai/code/session_01EYbRXASGVAYqZYmHLjD4Uy