### PR TITLE
Print edition: plan + press route + A5 PDF export (ISSUE 375 debut)

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -56,6 +56,46 @@ the shop is not the inventory.*
 - Not deployed (`npm run deploy` not run) — issue shipped on the feature
   branch `claude/investment-flipping-strategy-rAQSq` for review, not to
   gh-pages. Merge to main before any deploy or a main deploy overwrites.
+## Current Session (2026-05-30) — PRINT EDITION: GIVING THE MAGAZINE A BODY
+
+First move to put kernel.chat on physical paper. The publication was
+print-native from the start (POPEYE spine, stock/monument/colophon/
+postmark vocabulary, one tomato spot color) but had never existed as
+an object. This session built the plan + the tooling to render it.
+
+- **`docs/print-edition.md`** — the print-edition plan. Debut object:
+  ISSUE 375 (cream anchor stock, monument-hero number as cover art,
+  the credit-page issue — the right statement piece for issue #1).
+  Why risograph is the uncanny match (the whole brand IS one spot
+  color on warm uncoated stock = riso's native cheapest mode; tomato ≈
+  Riso Bright Red/Fluoro Orange). A5 saddle-stitch, 16pp, EB Garamond +
+  Courier Prime + Noto Serif JP (all OFL). Full 16pp page plan for 375,
+  production path, named riso/newsprint printers, Big Cartel/Gumroad
+  sell plan + budget math, 8-week timeline.
+- **Print route + tooling shipped:**
+  - `src/pages/PrintIssuePage.tsx` — `#/issues/:number/print`. Reuses
+    IssueCover/Contents/Feature/Credits/Colophon minus all web chrome
+    (no archive nav). Named export, explicit types.
+  - `src/pages/PrintIssuePage.css` — A5 `@page` geometry, page breaks
+    between blocks, `print-color-adjust: exact` so stock + tomato spot
+    actually render on press, plus a screen preview mode showing page
+    boundaries.
+  - `tools/print-issue.ts` — `npm run print 375` → `print/375.pdf`.
+    Spawns vite preview, renders the print route in headless Chromium
+    (Playwright), emits A5 PDF with backgrounds. Reusable per issue.
+  - `package.json` — added `"print"` script.
+- **Verification:** my files type-clean. `npx tsc --noEmit` shows ONLY
+  pre-existing tsconfig deprecation errors (esModuleInterop/
+  moduleResolution/baseUrl) from a newer TS in the container —
+  tsconfig.json untouched. Could not run the PDF render here (no
+  Chromium binary); it runs locally where Playwright's browser exists.
+- **Next:** visual pass on the print CSS against a rendered proof
+  (screen sections are viewport-sized, not 148mm pages — the page model
+  is in place but geometry needs tuning); then pre-flight (font
+  embedding, spot separation, 3mm bleed) and a printer quote.
+- Context: this session also covered job-search strategy (portfolio
+  from the repos; FDE/agent-infra targets) and pivoted to the print
+  object as the "one physical tangible thing" to make + sell.
 
 ## Current Session (2026-05-28, cont.) — EDITORIAL AGENT LAYER BUILD-OUT
 

--- a/docs/print-edition.md
+++ b/docs/print-edition.md
@@ -1,0 +1,159 @@
+# Print Edition — kernel.chat
+
+> The plan for putting kernel.chat on paper. Debut object: **ISSUE 375
+> — THE SIX BORROWS**, the issue that argues open-source pace is reading
+> discipline first. The magazine that has only ever existed in pixels
+> gets a body. This carries ISSUE 392's thesis — *the hand survives* —
+> into the object itself.
+
+---
+
+## I. Why this is the one tangible thing
+
+The publication was print-native from the first commit. The grammar is
+borrowed from a physical magazine (POPEYE, Tokyo). The vocabulary —
+stock, monument, colophon, postmark, dateline, folio — is print
+vocabulary. Sixteen-plus issues were designed for a paper object that
+never physically existed. **Printing it is a format change, not a new
+creation:** the content, the type system, the spot color, the ornament
+discipline are all already specified in `docs/design-language.md` and
+the issue files.
+
+It also sells the way a no-audience operation needs: a physical magazine
+is its own marketing. It photographs well, passes hand to hand, sits in
+indie bookshops and on a single-page web store. The object does the
+talking.
+
+---
+
+## II. Why risograph is the uncanny match
+
+The entire brand is **one spot color (tomato) on warm stock, black text,
+no process color.** That is *exactly* what a risograph is — a spot-color
+duplicator that prints one or two ink drums at a time onto uncoated
+paper. The constraint kernel.chat adopted as a discipline is risograph's
+native, cheapest mode.
+
+- **Inks:** Black + one warm red/orange drum (Riso "Bright Red,"
+  "Fluorescent Orange," or "Red" ≈ the tomato spot). Two-color riso is
+  the low-cost tier.
+- **Paper:** Riso runs natively on warm uncoated stock — a cream/manila
+  text weight *is* the `cream`/`butter` stock cabinet, achieved by the
+  paper choice rather than CSS.
+- **Texture:** Riso's slight misregistration and ink grain read as
+  craft, not error — the analog texture ISSUE 392 was about.
+
+If a studio can't do riso, the on-brand fallback is **digital newsprint**
+(newspaper-stock short runs) — also warm, also cheap, also a magazine
+object.
+
+---
+
+## III. Format spec (debut)
+
+| Spec | Decision | Why |
+|---|---|---|
+| **Trim** | A5 portrait (148 × 210 mm) | Cheapest riso format (folded A4), mailable, reads as indie art object. (Upgrade path: B5 / 257×182 — true POPEYE proportion — if you move to offset later.) |
+| **Binding** | Saddle-stitch (2 staples) | Standard for ≤40pp; flat, cheap, classic zine |
+| **Extent** | 16 pp (must be a multiple of 4) | Fits 375 — essay + references + colophon — without padding |
+| **Stock** | Text: warm cream uncoated ~120 gsm · Cover: same family ~250–300 gsm | Matches the `cream` anchor stock |
+| **Inks** | Black + 1 warm-red spot (tomato) | The whole color system, exactly |
+| **Type** | EB Garamond (body) · Courier Prime (labels/mono) · Noto Serif JP (bilingual lockups + house phrases) | Already the site's type system; all OFL-licensed for print |
+| **System glyph** | ★ as folio / page mark, per design-language | One mark everywhere — the ratified discipline |
+| **Run** | 50–100 copies | Test demand before scaling; riso minimums are low |
+
+---
+
+## IV. Page plan — ISSUE 375 (16 pp)
+
+```
+ 1  COVER        Monument-hero "375" as cover art + 1–6 borrows
+                 secondary lockup. Cream. Seal: CREDITED · SIX BORROWS.
+                 Wordmark, tagline (MAGAZINE FOR CITY CODERS /
+                 街のコーダーのために), price (¥0 · BYOK), ★.
+ 2  MASTHEAD     Colophon-lite: issue/month/year, editor's note,
+                 the bilingual featureJp lockup. Tomato rule.
+ 3  CONTENTS     The route in full — six borrows as a numbered
+                 catalog (paper → module → file).
+ 4–5 ESSAY I     "The Six Borrows" opening spread. Drop cap, body in
+                 Garamond, kicker in Courier. Tomato pull-quote.
+ 6–7 ESSAY II    The argument: reading discipline before code
+                 discipline. Methods/dossier sidebar adjacent to the
+                 claim (WIRED mechanic).
+ 8–9 ESSAY III   Borrows 1–6, each named, each routed. Borrow #4
+                 (forecast/, in-house) flagged BORROW vs IN-HOUSE.
+10–11 ESSAY IV   Close. The night as typesetting.
+12–13 REFERENCES The credit page — six arXiv IDs, numbered, set in
+                 body size with tomato superscript markers. (Verify
+                 IDs against V5_FUTURES_PLAN.md — they are real.)
+14  BACK MATTER  Editor's colophon: how it was made, run size,
+                 printer credit, "the hand survives" note.
+15  POSTMARK     Centred dateline (PAPERSKY mechanic), ★, the house
+                 phrases 残る希少 / 街のコーダーたちへ.
+16  BACK COVER   Quiet. Wordmark + ★ + a single tomato block. No
+                 cover lines (restraint, mechanic 6 from 370).
+```
+
+---
+
+## V. Production path (smallest, no-network route)
+
+1. **Build a print route + PDF export.** The site already ships
+   `puppeteer-core` and `@playwright/test` in devDependencies. Add a
+   `?print` route (or a dedicated print stylesheet: A5 page boxes,
+   CMYK-safe / spot-separable colors, embedded fonts, crop marks) and a
+   script that renders ISSUE 375 to a print-ready PDF. This is the one
+   step that needs the codebase — and it's reusable for every future
+   issue.
+2. **Pre-flight.** Confirm fonts embedded, images ≥300 dpi, spot color
+   isolated to one channel (so the printer can map it to the red drum),
+   bleed 3 mm, trim/crop marks on.
+3. **Choose a printer (PDF in, copies mailed out):**
+   - *Risograph studios (US):* Issue Press (Grand Rapids), Perfectly
+     Acceptable (Chicago), Tiny Splendor (LA), Risolve Studio. Most take
+     a PDF + a quote request by email and ship you the run.
+   - *Digital newsprint (dead-simple fallback):* Newspaper Club —
+     upload PDF, order short runs, ships to door. On-brand (newsprint =
+     magazine).
+4. **Proof one copy** before the full run.
+5. **Run 50–100.**
+
+---
+
+## VI. Sell (no audience required)
+
+- **Store:** a single-page Big Cartel or Gumroad (physical product) —
+  the object's photo is the whole pitch. Keep the editorial voice; the
+  store is the colophon, not a "shop."
+- **Price:** $18–25 per copy (indie riso norm). Newsprint can go lower
+  ($8–12) at higher volume.
+- **Budget math (riso, 16pp A5, ×100):** ~$300–500 printed → sell at
+  $20 → ~$2,000 gross / ~$1,500 net. Modest, real, tangible, and it
+  proves the format before you scale.
+- **Distribution that needs no network:** indie bookshops take zines on
+  consignment; zine fairs; mail one to each magazine you've decoded
+  (a PAPERSKY/WIRED-adjacent object lands well with that audience).
+
+---
+
+## VII. Timeline (≈8 weeks)
+
+| Week | Milestone |
+|---|---|
+| 1 | Print route + PDF export script; 375 renders to A5 PDF |
+| 2 | Pre-flight + design pass on print-specific tweaks (folios, bleed) |
+| 3 | Printer quotes; pick studio; send proof file |
+| 4 | Proof copy in hand; corrections |
+| 5 | Full run printed |
+| 6 | Big Cartel / Gumroad store live; photography |
+| 7 | First copies shipped; consignment outreach |
+| 8 | Restock decision based on sell-through |
+
+---
+
+## VIII. Next action
+
+Build step V.1 — the print route + PDF export — using the
+already-installed Playwright/puppeteer. That's the single thing that
+turns ISSUE 375 from a `.ts` file into a press-ready PDF, and it's
+reusable for every issue after.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "test:e2e": "playwright test",
         "test:e2e:update": "playwright test --update-snapshots",
         "deploy": "cd dist && git init && git add -A && git commit -m deploy && git push -f $(git -C .. remote get-url origin) HEAD:gh-pages && rm -rf .git",
+        "print": "npx tsx tools/print-issue.ts",
         "monitor": "npx tsx tools/kernel-monitor.ts",
         "discord": "npx tsx tools/discord-bot.ts",
         "cap:sync": "npx cap sync",

--- a/src/pages/PrintIssuePage.css
+++ b/src/pages/PrintIssuePage.css
@@ -1,0 +1,76 @@
+/* PrintIssuePage.css — page geometry for the print edition.
+ *
+ * Targets A5 portrait (148 x 210 mm), the debut trim documented in
+ * docs/print-edition.md. The screen components keep their own warm
+ * stock backgrounds and tomato spot color; this stylesheet only owns
+ * the paper: page size, breaks between major blocks, and the
+ * print-color-adjust flag that forces backgrounds + spot color to
+ * actually render on press (browsers strip them by default).
+ *
+ * Geometry here will need a visual pass against a rendered proof —
+ * screen sections are sized for the viewport, not for a 148mm page —
+ * but this establishes the page model the proof iterates from.
+ */
+
+@page {
+  size: 148mm 210mm; /* A5 portrait. Switch to 257mm 182mm for B5/offset. */
+  margin: 0;
+}
+
+/* Force every block to print its background + the tomato spot. */
+.pop-print,
+.pop-print * {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+.pop-print {
+  width: 148mm;
+  margin: 0 auto;
+  background: var(--color-paper, #faf9f6);
+}
+
+/* Each top-level block (cover, contents, feature, credits, colophon)
+   starts on a fresh leaf. break-after on every child but the last. */
+.pop-print > * {
+  break-after: page;
+  break-inside: avoid;
+  width: 148mm;
+  min-height: 210mm;
+  box-sizing: border-box;
+  /* neutralize any 100vh screen sizing so a block is one A5 page */
+  max-height: none;
+}
+
+.pop-print > *:last-child {
+  break-after: auto;
+}
+
+/* The cover is the front leaf — let it fill the trim edge to edge. */
+.pop-print .pop-cover,
+.pop-print [class*='cover'] {
+  margin: 0;
+}
+
+/* Hide any web-only affordances that slipped through (scroll cues,
+   sticky nav, share buttons). Print never wants interactive chrome. */
+.ka-print-page .ka-archive-nav,
+.ka-print-page nav,
+.ka-print-page button,
+.ka-print-page .ka-scroll-cue {
+  display: none !important;
+}
+
+/* Screen preview of the print route (when opened in a normal tab):
+   show page boundaries so the layout is legible before rendering. */
+@media screen {
+  body.ka-print-page {
+    background: #4a4a4a;
+    padding: 24px 0;
+  }
+  .pop-print > * {
+    background: var(--color-paper, #faf9f6);
+    box-shadow: 0 2px 18px rgba(0, 0, 0, 0.35);
+    margin: 0 auto 24px;
+  }
+}

--- a/src/pages/PrintIssuePage.tsx
+++ b/src/pages/PrintIssuePage.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react'
+import { useParams, Navigate } from 'react-router-dom'
+import { findIssue } from '../content/issues'
+import { IssueCover } from '../components/IssueCover'
+import { IssueContents } from '../components/IssueContents'
+import { IssueFeature } from '../components/IssueFeature'
+import { IssueCredits } from '../components/IssueCredits'
+import { IssueColophon } from '../components/IssueColophon'
+// Shares the cover/layout grammar with the landing + detail pages;
+// LandingPage.css owns the cover variants, PrintIssuePage.css adds the
+// page geometry (A5 trim, page breaks, spot-color print fidelity).
+import './LandingPage.css'
+import './PrintIssuePage.css'
+
+/**
+ * PrintIssuePage — the press surface for an issue.
+ *
+ * Renders the same cover + contents + feature + credits + colophon as
+ * the permanent issue URL, but strips every web-only chrome layer (the
+ * archive PREV/NEXT nav, scroll affordances) so the page maps cleanly
+ * to A5 paper. Consumed by tools/print-issue.ts, which loads this route
+ * headless and emits a print-ready PDF.
+ *
+ * Reachable at #/issues/:number/print.
+ */
+export function PrintIssuePage() {
+  const { number } = useParams<{ number: string }>()
+
+  useEffect(() => {
+    document.body.classList.add('ka-print-page')
+    return () => { document.body.classList.remove('ka-print-page') }
+  }, [])
+
+  if (!number) return <Navigate to="/issues" replace />
+  const issue = findIssue(number)
+  if (!issue) return <Navigate to="/issues" replace />
+
+  return (
+    <div className="pop-print" data-issue={issue.number}>
+      <IssueCover issue={issue} />
+      <IssueContents issue={issue} />
+      {issue.spread && <IssueFeature issue={issue} />}
+      {issue.credits && <IssueCredits issue={issue} />}
+      <IssueColophon issue={issue} />
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ const TermsPage = lazyRetry(() => import('./pages/TermsPage').then(m => ({ defau
 const IssuesPage = lazyRetry(() => import('./pages/IssuesPage').then(m => ({ default: m.IssuesPage })))
 const IssueDetailPage = lazyRetry(() => import('./pages/IssueDetailPage').then(m => ({ default: m.IssueDetailPage })))
 const IssueBackCoverPage = lazyRetry(() => import('./pages/IssueBackCoverPage').then(m => ({ default: m.IssueBackCoverPage })))
+const PrintIssuePage = lazyRetry(() => import('./pages/PrintIssuePage').then(m => ({ default: m.PrintIssuePage })))
 const BackCoversPage = lazyRetry(() => import('./pages/BackCoversPage').then(m => ({ default: m.BackCoversPage })))
 const RefusalsPage = lazyRetry(() => import('./pages/RefusalsPage').then(m => ({ default: m.RefusalsPage })))
 
@@ -58,6 +59,11 @@ export const router = createHashRouter([
       { path: 'issues/:number/back', element: withErrorBoundary(
         <Suspense fallback={<div className="ka-page-loading">Loading verso...</div>}>
           <IssueBackCoverPage />
+        </Suspense>
+      ) },
+      { path: 'issues/:number/print', element: withErrorBoundary(
+        <Suspense fallback={<div className="ka-page-loading">Loading press surface...</div>}>
+          <PrintIssuePage />
         </Suspense>
       ) },
       { path: 'back-covers', element: withErrorBoundary(

--- a/tools/print-issue.ts
+++ b/tools/print-issue.ts
@@ -1,0 +1,92 @@
+/**
+ * print-issue.ts — render one issue to a press-ready PDF.
+ *
+ * Loads the issue's print route (#/issues/<n>/print) in headless
+ * Chromium and emits an A5 PDF with backgrounds + the tomato spot color
+ * preserved. This is step V.1 of docs/print-edition.md: the one thing
+ * that turns an issue's .ts source into a file a printer can accept.
+ *
+ * Usage:
+ *   npm run build            # the preview server serves dist/
+ *   npm run print 375        # -> print/375.pdf
+ *
+ * Reusable for every issue. The PDF still needs a pre-flight pass
+ * (font embedding, spot-color separation, bleed) before press — see
+ * docs/print-edition.md section V.2 — but this produces the master.
+ */
+import { chromium } from '@playwright/test'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PORT = 4173
+const BASE = `http://localhost:${PORT}`
+const DIST = resolve(process.cwd(), 'dist')
+const OUT_DIR = resolve(process.cwd(), 'print')
+
+async function waitForServer(url: string, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    } catch {
+      // server not up yet
+    }
+    await new Promise((r) => setTimeout(r, 400))
+  }
+  throw new Error(`Preview server did not start within ${timeoutMs}ms`)
+}
+
+async function main(): Promise<void> {
+  const number = process.argv[2] ?? '375'
+
+  if (!existsSync(DIST)) {
+    console.error('No dist/ found. Run `npm run build` first.')
+    process.exit(1)
+  }
+
+  await mkdir(OUT_DIR, { recursive: true })
+
+  console.log(`Starting preview server on :${PORT} ...`)
+  const server: ChildProcess = spawn(
+    'npx',
+    ['vite', 'preview', '--port', String(PORT), '--strictPort'],
+    { stdio: 'ignore' },
+  )
+
+  try {
+    await waitForServer(BASE)
+
+    const browser = await chromium.launch()
+    const page = await browser.newPage()
+
+    const target = `${BASE}/#/issues/${number}/print`
+    console.log(`Rendering ${target} ...`)
+    await page.goto(target, { waitUntil: 'networkidle' })
+    await page.emulateMedia({ media: 'print' })
+    // Let webfonts (EB Garamond / Courier Prime / Noto Serif JP) settle.
+    await page.evaluate(() => document.fonts.ready)
+    await page.waitForTimeout(500)
+
+    const out = resolve(OUT_DIR, `${number}.pdf`)
+    await page.pdf({
+      path: out,
+      width: '148mm',
+      height: '210mm',
+      printBackground: true,
+      margin: { top: '0', right: '0', bottom: '0', left: '0' },
+    })
+
+    await browser.close()
+    console.log(`Wrote ${out}`)
+  } finally {
+    server.kill()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Give the magazine a body

The publication was print-native from the first commit — POPEYE spine, the `stock` / `monument` / `colophon` / `postmark` vocabulary, one tomato spot color — but had never existed as a physical object. This is the first move to put kernel.chat on paper, carrying ISSUE 392's thesis (*the hand survives*) into the object itself.

### What's here

**1. The plan — `docs/print-edition.md`**
- Debut object: **ISSUE 375 — THE SIX BORROWS** (cream anchor stock, monument-hero number as cover art, the credit-page issue — the right statement piece for issue #1).
- Why **risograph** is the uncanny match: the whole brand *is* one spot color on warm uncoated stock, which is riso's native, cheapest mode (tomato ≈ Riso Bright Red / Fluorescent Orange).
- A5 saddle-stitch, 16pp, EB Garamond + Courier Prime + Noto Serif JP (all OFL-licensed for print). Full 16pp page plan for 375, production path, named riso/newsprint printers, Big Cartel/Gumroad sell plan + budget math, 8-week timeline.

**2. The press route — `src/pages/PrintIssuePage.tsx` + `.css`**
- New route `#/issues/:number/print`. Reuses `IssueCover` / `IssueContents` / `IssueFeature` / `IssueCredits` / `IssueColophon` minus every web-only chrome layer (no archive nav).
- A5 `@page` geometry, page breaks between blocks, `print-color-adjust: exact` so the warm stock + tomato spot actually render on press, plus a screen preview mode that shows page boundaries.

**3. The export tool — `tools/print-issue.ts` + `npm run print`**
- `npm run build && npm run print 375` → `print/375.pdf`.
- Spawns `vite preview`, renders the print route in headless Chromium (Playwright, already a dependency), emits an A5 PDF with backgrounds preserved. Reusable for every issue.

### Verification
- My files are type-clean. `npx tsc --noEmit` reports **only pre-existing** tsconfig deprecation warnings (`esModuleInterop` / `moduleResolution` / `baseUrl`) from a newer TypeScript in the build container — `tsconfig.json` is untouched.
- The PDF render itself could not run in this container (no Chromium binary); it runs locally where Playwright's browser is installed.

### Next (not in this PR)
- Visual pass on the print CSS against a rendered proof — screen sections are viewport-sized, not 148mm pages, so the page model is in place but geometry needs tuning.
- Pre-flight: font embedding, spot-color separation, 3mm bleed.
- Printer quote + proof copy.

https://claude.ai/code/session_013H9jXskD9pThoBLdSxV2bG

---
_Generated by [Claude Code](https://claude.ai/code/session_013H9jXskD9pThoBLdSxV2bG)_