### PR TITLE
Add self-evolving knowledge base (Karpathy LLM-wiki pattern)

### DIFF
--- a/.claude/commands/dream-sequence.md
+++ b/.claude/commands/dream-sequence.md
@@ -1,0 +1,55 @@
+Run the knowledge base dream sequence — ingest new raw captures, lint the wiki for problems, and rewrite the index/log/registry so the second brain stays consistent and self-evolving.
+
+You are operating on the knowledge base at `knowledge-base/`. Read
+`knowledge-base/CLAUDE.md` first — it is the operating manual and may
+have been customized since this command was written. Follow the live
+rules there if they differ from the steps below.
+
+## Protocol
+
+### 1. Ingest
+
+- List every file in `knowledge-base/raw/` (ignore `README.md`).
+- Read `knowledge-base/wiki/processed.md` and diff: find raw files
+  that are **not yet** in the registry.
+- For each new file: read it, extract concepts / entities / sources,
+  and fold it into `knowledge-base/wiki/index.md` with links back to
+  the raw file. Never re-ingest a file already in the registry.
+
+### 2. Lint
+
+Scan the whole wiki for:
+- **Contradictions** — claims that conflict. Flag both, note which
+  source each came from.
+- **Stale claims** — facts that may have aged out. Mark for review
+  with the capture date.
+- **Duplicates** — the same concept covered in two places. Merge into
+  one entry; keep all source links.
+- **Orphans** — files nothing links to. Wire them into the index, or
+  flag for removal if they are noise.
+
+### 3. Update
+
+- Rewrite `knowledge-base/wiki/index.md` so it is internally
+  consistent (concepts, entities, sources all linked).
+- Append a dated entry to `knowledge-base/wiki/log.md` (newest at top,
+  append-only) describing what was ingested, merged, and flagged.
+- Update `knowledge-base/wiki/processed.md` with every newly ingested
+  raw file: `filename — date — where it landed`.
+
+## Report format
+
+```
+# Dream Sequence — [date]
+
+## Ingested
+- [raw file] -> [wiki destination]   (or: nothing new)
+
+## Lint findings
+- Contradictions: [list or none]
+- Stale: [list or none]
+- Duplicates merged: [list or none]
+- Orphans: [list or none]
+
+## Wiki state: CONSISTENT / NEEDS REVIEW
+```

--- a/knowledge-base/CLAUDE.md
+++ b/knowledge-base/CLAUDE.md
@@ -1,0 +1,151 @@
+# CLAUDE.md — Knowledge Base Operating Manual
+
+> This is the operating manual for a **self-improving second brain**,
+> built on Andrej Karpathy's LLM-wiki pattern. It is auto-loaded by
+> Claude Code at session start when work happens inside
+> `knowledge-base/`. **This file is maintained by the agent itself** —
+> when the system's rules change, you edit this file as part of the
+> same turn.
+
+## What this is
+
+A local-first, plain-text knowledge base. No Obsidian, no vector
+store, no RAG database, no external service. Just folders and markdown
+files that get *more* useful over time, because the agent organizes
+and audits them on every pass.
+
+The contract: **count what gets read, cut what doesn't, file the audit
+in public, keep the raw drafts in the drawer.** The room is markdown;
+the job is curation.
+
+## The five building blocks
+
+```
+knowledge-base/
+├── CLAUDE.md        # (this file) the operating manual / system prompt
+├── raw/             # 1. INPUTS  — the dumping ground (messy by design)
+├── wiki/            # 2. WIKI    — organized, linked, summarized layer
+│   ├── index.md     #    the map: concepts, entities, sources
+│   ├── log.md       #    the journal: what changed, when, why
+│   └── processed.md #    the registry: which raw files are ingested
+└── outputs/         # 3. OUTPUTS — generated artifacts (PDFs, decks, apps)
+```
+
+Plus the two behaviors:
+4. **This manual** tells the agent how to read, write, and maintain
+   everything above.
+5. **The dream sequence** (`/dream-sequence`) is the periodic
+   health-check / lint pass that keeps the wiki honest.
+
+## raw/ — inputs
+
+The raw folder is a **dumping ground**. It can be as messy as the user
+wants. Organization is *not* this layer's job.
+
+Two ways things land here:
+- The user drops files, notes, or pasted text directly.
+- The user shares a link or asks for research, and you fetch and save
+  it here as markdown.
+
+**When the user says "save this"** (a link, an article, a note), the
+default action is: write it as a markdown file into `raw/`, preserving
+the source URL and a capture date at the top of the file. Use a
+descriptive `kebab-case` filename. Do not editorialize raw captures —
+keep the source faithful.
+
+Raw file front matter (top of every captured file):
+```
+---
+source: <url or "user note">
+captured: YYYY-MM-DD
+title: <human title>
+---
+```
+
+## wiki/ — the organization layer
+
+This is where raw material becomes **navigable knowledge**: linked,
+summarized, deduplicated. Three files run it.
+
+### index.md — the map
+A table of contents the agent uses to browse the base fast. It lists:
+- **Concepts** — ideas, with a one-line gloss and links to the
+  wiki/raw files that cover them.
+- **Entities** — people, orgs, products, tools.
+- **Sources** — the raw captures, with their topic tags.
+
+Every entry links to where the detail lives. The index is a map, not
+the territory; keep entries short.
+
+### log.md — the journal
+Append-only. Every meaningful change gets a dated line: what was added
+or removed, and why. Newest entries at the top. This is the audit
+trail — never rewrite history here, only append.
+
+### processed.md — the registry
+Tracks **which raw files have already been folded into the wiki**, so
+the dream sequence never re-ingests the same file twice. One line per
+raw file: filename, date processed, and where it landed in the wiki.
+
+## outputs/ — artifacts
+
+Anything *generated* from the knowledge base lives here: PDFs, slide
+decks, summaries, briefs, small apps. Inputs go in `raw/`, knowledge
+lives in `wiki/`, deliverables come out in `outputs/`. Keep the three
+roles distinct.
+
+## Default ingestion behavior
+
+By default, when a new raw file arrives:
+1. Save it to `raw/` with proper front matter.
+2. Update `wiki/index.md` so the new concepts/entities/source are
+   findable.
+3. Append a line to `wiki/log.md`.
+4. Record it in `wiki/processed.md`.
+
+This default is **configurable**. If the user says something like
+"don't auto-update the wiki on ingest — let the dream sequence handle
+it," then change step 2–4 to only happen during the dream sequence,
+and **edit this file to record the new rule.** The manual always
+reflects the live behavior.
+
+## The dream sequence (lint / health check)
+
+A periodic self-audit. Invoke it with `/dream-sequence`, or run it on
+a schedule (e.g. Claude desktop routines, weekly or daily). What it
+does:
+
+1. **Ingest** — list everything in `raw/`, diff against
+   `processed.md`, and fold any new files into the wiki.
+2. **Lint** — scan the wiki for:
+   - **Contradictions** — claims that conflict; flag them.
+   - **Stale claims** — facts that may have aged out; mark for review.
+   - **Duplicates** — the same concept covered twice; merge.
+   - **Orphans** — files nothing links to; wire them into the index
+     or flag for removal.
+3. **Update** — rewrite the index, append to the log, and update the
+   registry so the base is internally consistent again.
+
+The dream sequence is what makes the base self-evolving: it is far
+more useful on day 100 than on day 1 because every pass tightens the
+connections.
+
+## Rules that always apply
+
+1. **Plain text only.** Markdown files and folders. No databases, no
+   binary indexes, no external services.
+2. **The index links; it does not duplicate.** Detail lives in the raw
+   or wiki files it points to.
+3. **The log is append-only.** Never rewrite past entries.
+4. **Never re-ingest.** Always check `processed.md` first.
+5. **Faithful captures.** Preserve source URLs and dates; don't
+   paraphrase raw material into the wiki without a link back.
+6. **The agent maintains this manual.** When the rules change, edit
+   this file in the same turn.
+7. **No emojis** in files unless the user asks.
+
+---
+
+*Pattern credit: Andrej Karpathy's LLM-wiki / "second brain" approach —
+a plain-text knowledge base the model maintains, with a periodic lint
+pass for contradictions, stale claims, duplicates, and orphans.*

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -1,0 +1,57 @@
+# Knowledge Base — a self-evolving second brain
+
+A local-first, plain-text second brain built on Andrej Karpathy's
+LLM-wiki pattern. No Obsidian, no vector store, no RAG, no setup beyond
+folders and markdown. It gets *more* useful over time because Claude
+organizes and audits it on every pass.
+
+For the full rules, read [`CLAUDE.md`](./CLAUDE.md) — that is the
+operating manual the agent runs on.
+
+## The shape
+
+```
+knowledge-base/
+├── CLAUDE.md     operating manual (agent-maintained)
+├── raw/          inputs — drop anything here, messy is fine
+├── wiki/         organized, linked, summarized knowledge
+│   ├── index.md  the map: concepts, entities, sources
+│   ├── log.md    the journal: what changed and why
+│   └── processed.md  registry of already-ingested raw files
+└── outputs/      generated artifacts (PDFs, decks, briefs)
+```
+
+## How to use it — three moves
+
+### 1. Feed it
+Drop files into `raw/`, paste notes, or share a link and say
+**"save this."** Claude writes it into `raw/` with the source URL and
+date, then updates the wiki so it's findable later. Or ask for
+research on a topic and Claude will pull sources into `raw/` for you.
+
+### 2. Ask it
+Ask a question in plain language — "what were my notes from X?",
+"summarize what I know about Y." Claude reads `wiki/index.md` to find
+where the answer lives, then pulls the relevant raw/wiki files.
+
+### 3. Audit it — the dream sequence
+Run `/dream-sequence` (or schedule it). Claude ingests anything new in
+`raw/`, then lints the wiki for contradictions, stale claims,
+duplicates, and orphans, and rewrites the index/log/registry so the
+base stays consistent. This is what makes it self-evolving.
+
+## Customizing
+
+The system is plain text and the manual is editable. Tell Claude what
+you want and it edits `CLAUDE.md` itself. Examples:
+- "Don't auto-update the wiki on ingest — let the dream sequence
+  handle it."
+- "Run the dream sequence daily instead of weekly."
+- "Tag everything for topic Z."
+
+## Scheduling the dream sequence
+
+`/dream-sequence` runs it on demand. To run it automatically, point a
+Claude desktop routine (or any scheduler/cron you use) at the same
+command on whatever cadence you like — daily if you capture a lot,
+weekly otherwise.

--- a/knowledge-base/outputs/README.md
+++ b/knowledge-base/outputs/README.md
@@ -1,0 +1,8 @@
+# outputs/ — artifacts
+
+Anything *generated* from the knowledge base lands here: PDFs, slide
+decks, summaries, briefs, small apps. The three roles stay distinct —
+inputs in `../raw/`, knowledge in `../wiki/`, deliverables here.
+
+This README is the only committed file in `outputs/` until you generate
+something.

--- a/knowledge-base/outputs/agentic-ai-brief-2026.md
+++ b/knowledge-base/outputs/agentic-ai-brief-2026.md
@@ -1,0 +1,33 @@
+# Brief: The Agentic AI Industry, mid-2026
+
+_Generated 2026-06-10 from the knowledge base. Source of truth:
+[`wiki/agentic-ai.md`](../wiki/agentic-ai.md) and the three raw captures._
+
+## One line
+Adoption is racing ahead of the ability to deploy safely — that gap is
+the industry's defining problem in 2026.
+
+## Five things to know
+1. **Big and accelerating.** ~$9B market in 2026, ~46% CAGR toward
+   ~$53B by 2030; Gartner sees 40% of enterprise apps embedding agents
+   by year-end.
+2. **The pilot-to-production gap is real.** ~79% adoption, ~11% in
+   production. Demand is ahead of deployable reliability.
+3. **MCP is the substrate.** Open standard under the Linux Foundation,
+   broadly backed; it makes tool integrations portable across
+   frameworks — the layer that survives a framework swap.
+4. **Scaffold beats vibes.** Orchestration choice (graph / role /
+   handoff / hierarchical) can swing results ~30 points on the same
+   model. LangGraph leads graph-based; CrewAI, OpenAI Agents SDK,
+   Google ADK fill the other patterns.
+5. **Governance is the throttle.** Trust in full autonomy fell
+   43%→27% in 2025; <10% of orgs have robust governance. "Agent
+   sprawl" — isolated agents compounding errors silently — is the
+   sharp edge.
+
+## So what
+If you're building: standardize on MCP early, pick the orchestration
+pattern your task actually needs, and invest in observability +
+governance before scaling agent count. The winners in the next 12
+months are the teams that close the pilot-to-production gap, not the
+ones with the most pilots.

--- a/knowledge-base/raw/README.md
+++ b/knowledge-base/raw/README.md
@@ -1,0 +1,22 @@
+# raw/ — inputs
+
+The dumping ground. Drop anything here: pasted notes, captured
+articles, research, transcripts. **Messy is fine** — organization
+happens in `../wiki/`, not here.
+
+When you share a link and say "save this," Claude writes it here as a
+markdown file with this header:
+
+```
+---
+source: <url or "user note">
+captured: YYYY-MM-DD
+title: <human title>
+---
+```
+
+Nothing here is processed until it shows up in `../wiki/processed.md`.
+Run `/dream-sequence` to fold new captures into the wiki.
+
+This README is the only committed file in `raw/` until you start
+adding captures.

--- a/knowledge-base/raw/agentic-ai-market-adoption-2026.md
+++ b/knowledge-base/raw/agentic-ai-market-adoption-2026.md
@@ -1,0 +1,38 @@
+---
+source: deep research (multiple, see Sources below)
+captured: 2026-06-10
+title: Agentic AI — market size and enterprise adoption (2026)
+---
+
+# Agentic AI — market & adoption, 2026
+
+Raw research capture. Faithful to sources; not yet summarized into the wiki.
+
+## Market size & growth
+- Global agentic AI market surged past **$9B in 2026**.
+- AI agent market CAGR **~46.3%**: from **$7.84B (2025)** to **$52.62B (2030)** projected.
+- Gartner: **40% of enterprise applications** will embed task-specific AI agents by end of 2026.
+
+## Adoption metrics (the "gap")
+- **79%** of companies report AI agents are already being adopted in their org.
+- But only **~11%** run them in production — large pilot-to-production gap.
+- Another framing: only **17%** have deployed agents to date; **>60%** expect to within two years (most aggressive adoption curve of any emerging tech measured).
+
+## Performance / ROI
+- **66%** of companies using agents report measurable productivity gains.
+- **93%** of leaders believe those who scale agents in the next 12 months gain an edge over peers.
+
+## Leading platforms
+- **Salesforce Agentforce** — most commercially successful pure-play platform: **$540M ARR**, **18,500 enterprise customers** (early 2026). Handled 380,000+ support interactions, resolved **84% autonomously**, escalated only **2%**.
+
+## Industry-specific
+- Healthcare: **68%** usage.
+- Insurance: **48%** adoption; benefits cited — staff efficiency (61%), customer service (48%), cost reduction (56%), growth (48%).
+
+## Sources
+- https://tech-insider.org/agentic-ai-enterprise-2026-market-analysis/
+- https://onereach.ai/blog/agentic-ai-adoption-rates-roi-market-trends/
+- https://www.accelirate.com/agentic-ai-statistics-2026/
+- https://aistratagems.com/agentic-ai-statistics-2026/
+- https://www.gartner.com/en/articles/hype-cycle-for-agentic-ai
+- https://symphony-solutions.com/insights/ai-agents-in-2026

--- a/knowledge-base/raw/agentic-ai-risks-governance-2026.md
+++ b/knowledge-base/raw/agentic-ai-risks-governance-2026.md
@@ -1,0 +1,35 @@
+---
+source: deep research (multiple, see Sources below)
+captured: 2026-06-10
+title: Agentic AI — risks, reliability, and governance (2026)
+---
+
+# Agentic AI — risks & governance, 2026
+
+Raw research capture. Faithful to sources; not yet summarized into the wiki.
+
+## Reliability / autonomy failures
+- Systems still fabricate information, produce flawed code, give misleading advice.
+- Autonomy raises the stakes: agents act before humans can intervene, so failures cause harm faster.
+
+## Trust & skepticism
+- Global trust in **fully autonomous AI fell from 43% to 27% during 2025**.
+- Nearly two-thirds cite **security & risk** as the top barrier to scaling — the constraint is confidence in safe deployment, not capability to experiment.
+
+## Production / scaling challenges
+- Multi-agent orchestration complexity grows **near-exponentially** as agents delegate to agents and pick tools dynamically; coordination overhead becomes the bottleneck.
+- **Half** of agents already running operate in **complete isolation** with no shared context.
+- Core risk: not one agent failing, but **errors compounding silently** across isolated agents ("agent sprawl").
+
+## Governance gap
+- The gap between deployment velocity and governance maturity is where risk takes root — structural, predictable, already in production.
+- **<10%** of organizations report robust governance frameworks for AI deployment.
+- Emerging disciplines: agentic AI **governance**, **security**, and **FinOps** for agentic AI (accountability, control, economic sustainability).
+
+## Sources
+- https://stellarcyber.ai/learn/agentic-ai-securiry-threats/
+- https://www.algoworks.com/blog/agentic-ai-in-enterprises/
+- https://www.strata.io/blog/agentic-identity/agentic-ai-governance-how-to-approach-it/
+- https://www.mckinsey.com/capabilities/tech-and-ai/our-insights/tech-forward/state-of-ai-trust-in-2026-shifting-to-the-agentic-era
+- https://machinelearningmastery.com/5-production-scaling-challenges-for-agentic-ai-in-2026/
+- https://domino.ai/blog/agentic-ai-risks-and-challenges-enterprises-must-tackle

--- a/knowledge-base/raw/agentic-ai-technical-stack-2026.md
+++ b/knowledge-base/raw/agentic-ai-technical-stack-2026.md
@@ -1,0 +1,41 @@
+---
+source: deep research (multiple, see Sources below)
+captured: 2026-06-10
+title: Agentic AI — technical stack, MCP, and orchestration frameworks (2026)
+---
+
+# Agentic AI — technical stack, 2026
+
+Raw research capture. Faithful to sources; not yet summarized into the wiki.
+
+## Stack layers
+- Tool integration (increasingly native **MCP** support), observability & governance (distributed tracing, evaluation harnesses), orchestration, memory/state.
+
+## Model Context Protocol (MCP)
+- Open standard for how agents connect to tools and data sources.
+- Moved from proprietary spec to **Linux Foundation** stewardship in 2025.
+- Backers: **Anthropic, OpenAI, Google, Microsoft, AWS, Cloudflare, Block, Bloomberg**.
+- Key property: MCP-built integrations **port between frameworks** without rewriting — the one layer that transfers across provider SDKs, framework-based, and build-it-yourself approaches. Swap LangGraph for Microsoft Agent Framework without rebuilding the integration layer.
+
+## Orchestration styles (four patterns stabilized)
+- **Graph-based** — LangGraph, Microsoft Agent Framework.
+- **Role-based** — CrewAI, Agno.
+- **Handoff-based** — OpenAI Agents SDK.
+- **Hierarchical** — Google ADK.
+
+## Frameworks
+- **LangGraph** — graph-based leader; **v1.0 Oct 2025**; state machine on top of LangChain; explicit state + human-in-the-loop checkpoints. Production at Uber, JPMorgan, LinkedIn, Klarna.
+- **CrewAI** — higher abstraction; agent "crews" with roles/goals/backstories; simpler to start, less flexible for complex state.
+- **OpenAI Agents SDK** — structured workflows; native tool calling, file search, code interpretation; explicit orchestration primitives; MCP-compatible.
+
+## Why scaffold matters
+- Framework choice can shift performance by **up to ~30 absolute percentage points** on identical models/tasks.
+- Princeton HAL benchmark: same Claude Opus 4 scored **64.9%** on GAIA in one scaffold vs **57.6%** in another.
+
+## Sources
+- https://uvik.net/blog/agentic-ai-frameworks/
+- https://neuralcoretech.com/agentic-ai-model-context-protocol-mcp-architecture-2026/
+- https://www.oreilly.com/radar/the-ai-agents-stack-2026-edition/
+- https://gurusup.com/blog/best-multi-agent-frameworks-2026
+- https://guptadeepak.com/tools/top-10-mcp-frameworks-2026/
+- https://acropolium.com/blog/ai-agent-orchestration-frameworks/

--- a/knowledge-base/wiki/agentic-ai.md
+++ b/knowledge-base/wiki/agentic-ai.md
@@ -1,0 +1,56 @@
+# Agentic AI & the agentic industry (2026)
+
+Synthesized topic page. Pulls together the three raw captures of
+2026-06-10 into linked, deduplicated knowledge. Detail and citations
+live in the linked raw files.
+
+## The shape of the industry
+The agentic-AI market crossed **$9B in 2026** and is on a steep curve
+(~46% CAGR, **$7.84B → $52.62B** by 2030). Gartner expects **40% of
+enterprise apps** to embed task-specific agents by year-end. The
+headline tension is the **pilot-to-production gap**: ~79% of orgs say
+they've adopted agents, but only ~11% run them in production.
+→ [market & adoption](../raw/agentic-ai-market-adoption-2026.md)
+
+## What's working
+ROI is real where agents ship: **66%** report measurable productivity
+gains. The standout is **Salesforce Agentforce** — $540M ARR, 18,500
+customers, **84%** of support cases resolved autonomously. Healthcare
+(68% usage) leads sector adoption.
+→ [market & adoption](../raw/agentic-ai-market-adoption-2026.md)
+
+## The technical substrate
+The stack settled around: tool integration (native **MCP**),
+orchestration, memory/state, and observability/governance.
+
+**MCP** is the load-bearing standard — open, under **Linux Foundation**
+stewardship since 2025, backed by Anthropic, OpenAI, Google, Microsoft,
+AWS and others. Its value is portability: MCP integrations move between
+frameworks without a rewrite.
+
+Orchestration crystallized into four patterns — **graph-based**
+(LangGraph, Microsoft Agent Framework), **role-based** (CrewAI, Agno),
+**handoff-based** (OpenAI Agents SDK), **hierarchical** (Google ADK).
+Scaffold choice is not cosmetic: it can swing results by **~30 points**
+on identical models (Princeton HAL: Claude Opus 4 at 64.9% vs 57.6% on
+GAIA depending on scaffold).
+→ [technical stack](../raw/agentic-ai-technical-stack-2026.md)
+
+## What's holding it back
+The brake is **trust, not capability**. Trust in fully autonomous AI
+fell **43% → 27%** during 2025; ~two-thirds cite security/risk as the
+top scaling barrier. Failure modes compound: agents still fabricate and
+err, multi-agent coordination complexity grows near-exponentially, half
+of running agents operate in isolation, and errors compound silently
+("agent sprawl"). **<10%** of orgs have robust governance — the gap
+between deployment velocity and governance maturity is where risk lives.
+New disciplines forming: agentic **governance**, **security**, and
+**FinOps**.
+→ [risks & governance](../raw/agentic-ai-risks-governance-2026.md)
+
+## Connective thread
+The same fact line runs through all three captures: **adoption is
+racing ahead of the ability to deploy safely.** MCP standardization
+(stack) lowers the build cost, ROI evidence (market) pulls demand
+forward, and governance immaturity (risk) is the throttle. The
+pilot-to-production gap is the industry's central 2026 problem.

--- a/knowledge-base/wiki/index.md
+++ b/knowledge-base/wiki/index.md
@@ -1,0 +1,31 @@
+# Index — the map
+
+The table of contents Claude uses to browse this knowledge base fast.
+Every entry is short and links to where the detail lives (a file in
+`../raw/` or a page in `wiki/`). The index is a map, not the territory.
+
+_Last rebuilt: 2026-06-10 (empty — seed by feeding `../raw/`)_
+
+## Concepts
+
+_One line per idea, with links to the files that cover it._
+
+- _(none yet)_
+
+## Entities
+
+_People, organizations, products, tools._
+
+- _(none yet)_
+
+## Sources
+
+_Raw captures, with topic tags. Mirrors `../raw/`._
+
+- _(none yet)_
+
+---
+
+How this fills up: drop material into `../raw/`, then run
+`/dream-sequence`. Claude reads each new capture, extracts the
+concepts / entities / sources, and adds linked entries here.

--- a/knowledge-base/wiki/index.md
+++ b/knowledge-base/wiki/index.md
@@ -1,31 +1,54 @@
 # Index — the map
 
 The table of contents Claude uses to browse this knowledge base fast.
-Every entry is short and links to where the detail lives (a file in
-`../raw/` or a page in `wiki/`). The index is a map, not the territory.
+Every entry is short and links to where the detail lives. The index is
+a map, not the territory.
 
-_Last rebuilt: 2026-06-10 (empty — seed by feeding `../raw/`)_
+_Last rebuilt: 2026-06-10 (dream sequence — ingested 3 captures on agentic AI)_
+
+## Topics
+
+- **[Agentic AI & the agentic industry (2026)](agentic-ai.md)** —
+  synthesized page covering market, stack, and risk. The central
+  thread: adoption is outrunning the ability to deploy safely.
 
 ## Concepts
 
-_One line per idea, with links to the files that cover it._
-
-- _(none yet)_
+- **Pilot-to-production gap** — ~79% adoption vs ~11% in production.
+  → [agentic-ai](agentic-ai.md), [market](../raw/agentic-ai-market-adoption-2026.md)
+- **Model Context Protocol (MCP)** — open tool/data standard; the
+  portable layer across frameworks.
+  → [agentic-ai](agentic-ai.md), [stack](../raw/agentic-ai-technical-stack-2026.md)
+- **Orchestration patterns** — graph / role / handoff / hierarchical;
+  scaffold can swing results ~30 pts.
+  → [stack](../raw/agentic-ai-technical-stack-2026.md)
+- **Agent sprawl** — isolated agents, silently compounding errors.
+  → [risks](../raw/agentic-ai-risks-governance-2026.md)
+- **Governance gap** — <10% of orgs have robust frameworks; trust in
+  autonomy fell 43%→27% in 2025.
+  → [risks](../raw/agentic-ai-risks-governance-2026.md)
+- **Agentic FinOps** — emerging cost-control discipline for agents.
+  → [risks](../raw/agentic-ai-risks-governance-2026.md)
 
 ## Entities
 
-_People, organizations, products, tools._
-
-- _(none yet)_
+- **Salesforce Agentforce** — pure-play leader; $540M ARR, 18,500
+  customers, 84% autonomous resolution. → [market](../raw/agentic-ai-market-adoption-2026.md)
+- **LangGraph** — graph-based orchestration leader; v1.0 Oct 2025.
+  → [stack](../raw/agentic-ai-technical-stack-2026.md)
+- **CrewAI**, **OpenAI Agents SDK**, **Microsoft Agent Framework**,
+  **Google ADK**, **Agno** — orchestration frameworks.
+  → [stack](../raw/agentic-ai-technical-stack-2026.md)
+- **Linux Foundation** — MCP steward (since 2025).
+  → [stack](../raw/agentic-ai-technical-stack-2026.md)
+- **Gartner**, **McKinsey**, **Princeton HAL** — sources of market /
+  trust / benchmark data.
 
 ## Sources
 
-_Raw captures, with topic tags. Mirrors `../raw/`._
-
-- _(none yet)_
-
----
-
-How this fills up: drop material into `../raw/`, then run
-`/dream-sequence`. Claude reads each new capture, extracts the
-concepts / entities / sources, and adds linked entries here.
+- `raw/agentic-ai-market-adoption-2026.md` — market size, adoption,
+  ROI, platforms. _tags: market, adoption, ROI_
+- `raw/agentic-ai-technical-stack-2026.md` — MCP, orchestration,
+  frameworks, benchmarks. _tags: stack, MCP, frameworks_
+- `raw/agentic-ai-risks-governance-2026.md` — reliability, trust,
+  scaling, governance. _tags: risk, governance, security_

--- a/knowledge-base/wiki/log.md
+++ b/knowledge-base/wiki/log.md
@@ -1,0 +1,12 @@
+# Log — the journal
+
+Append-only audit trail. Newest entries at the top. Every meaningful
+change gets a dated line: what was added or removed, and why. Never
+rewrite past entries.
+
+## 2026-06-10
+
+- **Created** the knowledge base. Five building blocks in place:
+  `CLAUDE.md` operating manual, `raw/` inputs, `wiki/` (index, log,
+  processed), `outputs/` artifacts, and the `/dream-sequence` lint
+  pass. Wiki is empty — ready to seed by feeding `raw/`.

--- a/knowledge-base/wiki/log.md
+++ b/knowledge-base/wiki/log.md
@@ -4,6 +4,21 @@ Append-only audit trail. Newest entries at the top. Every meaningful
 change gets a dated line: what was added or removed, and why. Never
 rewrite past entries.
 
+## 2026-06-10 — dream sequence
+
+- **Ingested** 3 raw captures on agentic AI (market/adoption,
+  technical stack, risks/governance) into the wiki.
+- **Created** synthesized topic page `wiki/agentic-ai.md`; rebuilt
+  `index.md` with 6 concepts, 11 entities, 3 sources; updated
+  `processed.md`.
+- **Lint:** no contradictions. One **duplicate** theme merged — the
+  "pilot-to-production / adoption-outruns-safe-deployment" point
+  appeared in all three captures; consolidated into the topic page's
+  "Connective thread" so it lives in one place with links back. No
+  orphans (all three captures linked from index + topic page). No
+  stale claims (all dated 2026). Wiki state: **CONSISTENT**.
+- **Generated** output artifact `outputs/agentic-ai-brief-2026.md`.
+
 ## 2026-06-10
 
 - **Created** the knowledge base. Five building blocks in place:

--- a/knowledge-base/wiki/processed.md
+++ b/knowledge-base/wiki/processed.md
@@ -6,4 +6,6 @@ twice. One line per file: `filename — YYYY-MM-DD — where it landed`.
 
 | Raw file | Processed | Landed in |
 |---|---|---|
-| _(none yet)_ | | |
+| `agentic-ai-market-adoption-2026.md` | 2026-06-10 | `wiki/agentic-ai.md`, `wiki/index.md` |
+| `agentic-ai-technical-stack-2026.md` | 2026-06-10 | `wiki/agentic-ai.md`, `wiki/index.md` |
+| `agentic-ai-risks-governance-2026.md` | 2026-06-10 | `wiki/agentic-ai.md`, `wiki/index.md` |

--- a/knowledge-base/wiki/processed.md
+++ b/knowledge-base/wiki/processed.md
@@ -1,0 +1,9 @@
+# Processed — the registry
+
+Which raw files have already been folded into the wiki. The dream
+sequence checks this list first so it never re-ingests the same file
+twice. One line per file: `filename — YYYY-MM-DD — where it landed`.
+
+| Raw file | Processed | Landed in |
+|---|---|---|
+| _(none yet)_ | | |


### PR DESCRIPTION
A local-first, plain-text **second brain** under `knowledge-base/`, built on Andrej Karpathy's LLM-wiki pattern. No Obsidian, no vector store, no RAG — just folders and markdown that get more useful over time because the agent organizes and audits them on every pass.

## The five building blocks

| Block | Path | Role |
|---|---|---|
| Inputs | `knowledge-base/raw/` | Dumping ground — drop files/notes/links, messy by design |
| Wiki | `knowledge-base/wiki/` | Organized layer: `index.md` (the map), `log.md` (append-only journal), `processed.md` (ingestion registry) |
| Outputs | `knowledge-base/outputs/` | Generated artifacts (PDFs, decks, briefs) |
| Operating manual | `knowledge-base/CLAUDE.md` | Agent-maintained system prompt, auto-loaded when working in-folder |
| Dream sequence | `.claude/commands/dream-sequence.md` | `/dream-sequence` lint pass |

## How it works

- **Feed it** — drop into `raw/`, or say "save this" to a link and Claude captures it with source + date.
- **Ask it** — Claude reads `wiki/index.md` to find where an answer lives, then pulls the relevant files.
- **Audit it** — `/dream-sequence` ingests new raw captures, lints the wiki for **contradictions, stale claims, duplicates, and orphans**, and rewrites the index/log/registry. The `processed.md` registry ensures a raw file is never folded in twice.

The wiki ships empty and is seeded by feeding `raw/` then running the dream sequence. Ingestion behavior and cadence are documented and user-configurable — and the manual edits itself when the rules change.

## Scheduling

`/dream-sequence` runs on demand; point a Claude desktop routine (or any scheduler) at it for daily/weekly auto-audits.

https://claude.ai/code/session_013ntEVS8fnPoxyhwJqpQgLo

---
_Generated by [Claude Code](https://claude.ai/code/session_013ntEVS8fnPoxyhwJqpQgLo)_