### PR TITLE
docs: reconcile Figma Motion (Config 2026) with the motion contract

### DIFF
--- a/docs/figma-motion-session.md
+++ b/docs/figma-motion-session.md
@@ -1,0 +1,113 @@
+# Session log — Figma Motion research & policy
+
+*Recorded 2026-06-25. Branch `claude/figma-motion-cdltib`, PR #53.
+This is the working record behind [`figma-motion.md`](./figma-motion.md):
+the question that started it, what the research found, and the
+decisions that followed.*
+
+## The question
+
+> "What is figma motion?"
+
+It started as a lookup against the branch name `figma-motion`. There
+was no "figma motion" concept anywhere in the codebase — the term
+only existed as the auto-generated branch name. That triggered a
+deep-research pass, which surfaced the real answer: **Figma Motion is
+a product Figma shipped at Config 2026 (announced 2026-06-24)** — one
+day before this session.
+
+## What the research found
+
+Sourced from Figma's blog/release notes, TechCrunch, motion.dev,
+LottieFiles, Figma Help, and 2026 tool comparisons.
+
+### 1. Figma's native motion features
+- **Figma Motion (new, June 2026, open beta):** a timeline on the
+  canvas. Keyframes position / scale / rotation / opacity
+  independently; presets (fade, move, scale); auto-keyframing; motion
+  variables (shared easing). Exports CSS / JSON / React / motion.dev
+  code, plus MP4 / WebM / SVG / GIF. Design-system propagation gated
+  to paid plans. 3D transforms announced via waitlist (not shipped).
+- **Smart Animate (established):** prototype-only transitions between
+  frames; matches layers by name + hierarchy; linear / ease / custom
+  bézier / spring easing. Can't animate Arc-tool objects (falls back
+  to dissolve).
+
+### 2. Figma → code handoff
+Three paths, decreasing fit for a CSS-only site:
+- **Native CSS export** (Dev Mode → copy CSS) — the only path that
+  can avoid shipping JS.
+- **Lottie / dotLottie** — ships a player runtime; cited ~60% smaller
+  than GIF / dotLottie ~98% (LottieFiles' own numbers).
+- **Framer Motion / motion.dev** via Figma Make / Sites — emits React
+  with a JS animation runtime.
+
+### 3. Fit for kernel.chat
+Only the CSS export clears the design-language bar (CSS-only, no JS
+animation libs, no Framer Motion, `prefers-reduced-motion`, animate
+only `opacity`/`transform`). React and Lottie outputs are off-policy.
+
+### 4. Landscape
+2026 consensus is specialization, not one tool: Figma = ideation/spec,
+Rive = production 2D / state machines (lightweight, perf), Spline = 3D
+web, Lottie = vector handoff, **raw CSS = the right shipping target
+for an editorial site.**
+
+## The name collision (the crux)
+
+Two different things are called "Motion":
+
+| Name | What it is | Standing |
+|---|---|---|
+| **Figma Motion** | Native canvas timeline (authoring tool) | Allowed as a spec surface |
+| **Motion / Framer Motion** (`motion.dev`) | JS animation runtime | Already banned by design-language rule 3 |
+
+The "no Framer Motion" rule was always about the *library*, not the
+authoring tool. Figma Motion doesn't change it.
+
+## Decisions shipped
+
+- **`docs/figma-motion.md`** — the standing policy:
+  > Figma Motion may author. Only CSS ships.
+  Allowed: Figma Motion as a spec surface; its CSS export, hand-finished
+  (re-clamp to ≤8% opacity / ≤4px translate, guard via
+  `prefers-reduced-motion`, `opacity`+`transform` only, strip any JS
+  rider, run the third-accent audit). Off-policy: React / Lottie /
+  dotLottie / runtime-player outputs.
+- **PR #53** opened as draft.
+
+## How Figma helps kernel.chat (practical map)
+
+Figma is a **drafting table**, not the press:
+- **Comp new issue spreads** at 393px before building in `pop-*`.
+- **Mirror tokens as Figma variables** (type ramp `--text-xs…2xl`,
+  paper stocks, letter-spacing tiers) so comps stay on-grammar.
+- **Preview a candidate accent hex** on ivory / butter / kraft / ink
+  before committing a seed (the `accents.ts` one-hex→5-tone system).
+- **Compose cover / back-cover art.**
+- **Figma Motion as a motion spec** → CSS export, hand-finished.
+
+Don't use: Figma Make/Sites codegen (React + framer-motion), Figma →
+Tailwind/component export, Lottie export, or Dev Mode "copy code"
+classes (read it only for measurements).
+
+## Live Figma ↔ Claude (the MCP note)
+
+Figma's Dev Mode MCP server serves at `http://127.0.0.1:3845/mcp`.
+It can't be reached from a **remote web session** — that runs in a
+cloud container whose `127.0.0.1` is not the user's machine. To use
+it live, run Claude Code **locally** alongside the Figma desktop app:
+enable "Dev Mode MCP Server" in Figma preferences, then
+`claude mcp add --transport http figma http://127.0.0.1:3845/mcp`.
+Even then, prefer `get_variable_defs` / `get_image` and transcribe by
+hand — `get_code` emits React/Tailwind, off-policy here.
+
+## Sources
+
+- Figma — [Introducing Figma Motion](https://www.figma.com/blog/introducing-figma-motion/)
+- Figma — [Config 2026 recap](https://www.figma.com/blog/config-2026-recap/)
+- TechCrunch — [Figma adds code layers + animations (2026-06-24)](https://techcrunch.com/2026/06/24/figma-adds-code-layers-support-for-animations-more-ai-features-in-new-update/)
+- motion.dev — [Figma integration](https://motion.dev/docs/figma)
+- Figma Help — [Smart Animate](https://help.figma.com/hc/en-us/articles/360039818874-Smart-animate-layers-between-frames) · [easing & spring](https://help.figma.com/hc/en-us/articles/360051748654-Prototype-easing-and-spring-animations)
+- LottieFiles — [for Figma](https://lottiefiles.com/plugins/figma)
+- illustration.app — [Figma vs Spline vs Rive 2026](https://www.illustration.app/blog/which-tool-wins-for-motion-branding-in-2026-figma-spline-or-rive)

--- a/docs/figma-motion.md
+++ b/docs/figma-motion.md
@@ -1,0 +1,104 @@
+# Figma Motion vs. the kernel.chat motion contract
+
+> **Decision in one line:** Figma Motion is welcome as an
+> *authoring/spec* surface. Only its **CSS export** may reach the
+> repo, hand-finished under the existing ambient-motion rules.
+> The React, Lottie, and runtime-player outputs are **off-policy**
+> and do not ship.
+
+Filed 2026-06-25. Trigger: Figma shipped a product literally named
+"Figma Motion" at Config 2026 (announced 2026-06-24), and the name
+collides with a library this project already bans. This note draws
+the line so the collision doesn't quietly erode the motion contract
+in [`design-language.md`](./design-language.md) (§ *Ambient motion —
+the two accents*).
+
+## The name collision
+
+Two different things are called "Motion." They are not the same and
+must not be treated the same.
+
+| Name | What it actually is | Standing here |
+|---|---|---|
+| **Figma Motion** | Figma's native canvas timeline (keyframes for position / scale / rotation / opacity, presets, motion variables, export to CSS / JSON / React / video). Open beta as of June 2026. | A **design tool**. Allowed as a spec surface. |
+| **Motion / Framer Motion** (`motion.dev`, `framer-motion`) | A JavaScript animation runtime. What Figma Make / Figma Sites emit when they "add animation." | A **JS library**. Already banned by design-language rule 3. |
+
+The design language's "no Framer Motion" line was always about the
+*runtime library*, not the authoring tool. Figma Motion does not
+change that line. It changes only *how a designer might author* the
+motion we then rebuild by hand in CSS.
+
+## What Figma Motion exports, mapped to our contract
+
+The contract (design-language § *Rules for new ambient motion*):
+amplitudes ≤ 8% opacity or ≤ 4px translate; respects
+`prefers-reduced-motion`; **CSS-only — no JS animation libraries, no
+Framer Motion, no `requestAnimationFrame`**; animate only `opacity`
+and `transform`; audit before adding a third accent.
+
+| Figma Motion output | Ships JS? | Auto-respects reduced-motion? | Verdict |
+|---|---|---|---|
+| **CSS export** (Dev Mode → copy CSS) | No, if you take only the CSS | **No** — you add the guard yourself | ✅ Allowed, as a *draft* to hand-finish |
+| React / `motion.dev` export | Yes (JS runtime) | Library-dependent | ❌ Breaks rule 3 by name |
+| Lottie / dotLottie | Yes (player runtime) | No | ❌ Breaks the CSS-only rule |
+| MP4 / WebM / GIF / animated SVG | n/a (asset, not motion code) | n/a | Out of scope; treat as an image asset, subject to weight budget |
+
+So exactly one path is open: **author in Figma Motion, export CSS,
+then rewrite it to fit.** The export is never paste-and-ship.
+
+## The hand-finish checklist
+
+When a CSS export comes off the Figma canvas, it does not enter the
+repo until it has been reduced to our terms:
+
+1. **Re-clamp amplitude.** Figma defaults are UI-scale (200–500ms,
+   visible moves). Our accents are imperceptible: ≤ 8% opacity or
+   ≤ 4px translate. If a reviewer wouldn't have to be *told* it
+   moves, it's still too big.
+2. **Guard it.** The site-wide `prefers-reduced-motion` override in
+   `src/index.css` collapses `animation-duration` to 0.01ms — make
+   sure the keyframe rides that override and isn't driven by a
+   property the override doesn't reach (e.g. a `transition` on a
+   non-animation property).
+3. **`opacity` and `transform` only.** Drop any exported keyframe
+   that touches layout, `filter`, `box-shadow`, `background-position`,
+   etc. — they are repaint/layout hotspots (rule 4).
+4. **No JS rider.** Strip any `import`, any `requestAnimationFrame`,
+   any `motion.*` wrapper. If the effect can't survive as pure CSS,
+   it doesn't belong on the site.
+5. **Run the third-accent audit.** The site's character is stillness
+   with two quiet accents (tomato-rule breath, dateline marquee).
+   Before a *third* lands, prove the existing two aren't enough
+   (rule 5). Figma making motion cheap to author is not a reason to
+   add more of it.
+
+## Where Figma Motion genuinely helps
+
+- **Pinning easing and timing** before writing a keyframe by hand —
+  the timeline is faster than eyeballing a cubic-bézier.
+- **Motion variables** as a shared easing vocabulary, then
+  transcribed into our CSS custom properties (not imported).
+- **A spec a reviewer can scrub**, instead of a prose description of
+  a 3.3s breath.
+
+It is a sketchbook, not a press. The press is still pure CSS.
+
+## Caveats
+
+- **It's days-old open beta.** CSS-export fidelity and motion-variable
+  behavior are unproven in public. Do not build a workflow dependency
+  on it yet; treat any export as a draft, not a source of truth.
+- **Design-system features are paywalled.** Animated-component
+  propagation and motion variables sit on paid plans; basic export
+  is broader. BYOK-adjacent principle: don't make the magazine's
+  motion pipeline depend on a seat tier.
+
+## The standing rule
+
+> Figma Motion may author. Only CSS ships. The motion contract in
+> `design-language.md` is unchanged — stillness with two quiet
+> accents, CSS-only, reduced-motion-respected — and a slicker
+> authoring tool is not a license to loosen it.
+
+See also: [`design-language.md`](./design-language.md) §§ *Ambient
+motion*, *Mobile design philosophy → Implemented rules*.

--- a/docs/figma-tokens-to-variables.md
+++ b/docs/figma-tokens-to-variables.md
@@ -1,0 +1,210 @@
+# Mirroring kernel.chat tokens as Figma variables
+
+> **Decision in one line:** Figma is a **drafting table**, not the
+> press. Mirror the design tokens into Figma variables so comps stay
+> on-grammar — then transcribe finished work back into CSS **by hand.**
+> The CSS in the repo is the source of truth; the Figma file is a
+> sketch of it, never the reverse.
+
+Filed 2026-06-25. Follow-up to [`figma-motion.md`](./figma-motion.md)
+and its session log's "Figma as a drafting table" map. Where that note
+drew the line on *motion*, this one does the same for *tokens*: which
+ones map cleanly to Figma variables, which ones can't, and how to keep
+the two in sync without ever running codegen.
+
+Token source of truth: the `tokens/` files in the
+`kernel-chat-design` skill (`colors.css`, `typography.css`,
+`spacing.css`, `fonts.css`) and `src/components/IssueAccent.css` for
+the adaptive accent system.
+
+## The one rule that makes this safe
+
+**Names match, one-to-one.** Every Figma variable is named after the
+CSS custom property it stands for, minus the `--` and with `/` for
+grouping. `--pop-tomato` → `color/pop/tomato`. `--space-lg` →
+`space/lg`. `--text-2xl` → `size/text-2xl`.
+
+That mechanical naming is the whole trick: when you finish a comp and
+read its variables back (via `get_variable_defs`, or by eye), each one
+already tells you the exact token to type into CSS. No translation
+layer, no judgment call, no drift.
+
+## What maps cleanly
+
+These tokens are static values. They cross into Figma variables with
+full fidelity. Build them as one **Primitives** collection (single
+mode), grouped by the paths below.
+
+### Color — `tokens/colors.css`
+
+| CSS token | Figma variable | Value |
+|---|---|---|
+| `--rubin-ivory` | `color/rubin/ivory` | `#FAF9F6` *(primary ground — never `#fff`)* |
+| `--rubin-ivory-med` | `color/rubin/ivory-med` | `#F0EEE6` |
+| `--rubin-ivory-dark` | `color/rubin/ivory-dark` | `#E8E6DC` *(hairlines)* |
+| `--rubin-slate` | `color/rubin/slate` | `#1F1E1D` *(primary ink)* |
+| `--rubin-slate-muted` | `color/rubin/slate-muted` | `#6B6966` *(secondary text)* |
+| `--pop-ivory` | `color/pop-stock/ivory` | `#FAF9F6` |
+| `--pop-cream` | `color/pop-stock/cream` | `#F3E9D2` *(anchor paper)* |
+| `--pop-butter` | `color/pop-stock/butter` | `#EFD9A0` |
+| `--pop-kraft` | `color/pop-stock/kraft` | `#C8A97E` |
+| `--pop-ledger` | `color/pop-stock/ledger` | `#F2EFE2` |
+| `--pop-coffee` | `color/pop-stock/coffee` | `#6B4E3D` |
+| `--pop-ink` | `color/pop-stock/ink` | `#1F1E1D` |
+| `--pop-tomato` | `color/spot/tomato` | `#E24E1B` *(the only spot)* |
+| `--pop-hairline` | `color/rule/hairline` | `rgba(31,30,29,0.85)` |
+| `--pop-hairline-soft` | `color/rule/hairline-soft` | `rgba(31,30,29,0.16)` |
+| `--rubin-primary` | `color/mark/purple` | `#6B5B95` *(logo mark ONLY)* |
+
+Two guardrails to carry into the file as it's built:
+- **No pure white.** Figma defaults frames to `#FFFFFF`; the first move
+  on any kernel.chat comp is to set the page fill to
+  `color/pop-stock/ivory`. There is no `#fff` in the system.
+- **Purple is not a colour you design with.** `color/mark/purple`
+  exists only so the logo mark renders. Tomato is the only spot the
+  press mixes.
+
+### Spacing, radii — `tokens/spacing.css`
+
+Float variables. Group `space/*` and `radius/*`.
+
+| CSS token | Figma variable | Value |
+|---|---|---|
+| `--space-xs … --space-4xl` | `space/xs … space/4xl` | 4 · 8 · 12 · 16 · 24 · 32 · 48 · 64 |
+| `--radius-xs … --radius-lg` | `radius/xs … radius/lg` | 3 · 6 · 10 · 20 |
+| `--radius-full` | `radius/full` | 9999 |
+
+Editorial surfaces stay square — `radius/*` is for the few framed
+surfaces (install pill, inset card) only.
+
+### Type ramp & tracking — `tokens/typography.css`
+
+Sizes and tracking become float variables; the two families become
+**text styles** (Figma can't hold a font family in a variable usefully,
+so a text style per role is the right container).
+
+| CSS token | Figma variable / style | Value |
+|---|---|---|
+| `--text-xs … --text-2xl` | `size/text-xs … size/text-2xl` | 12.8 · 16 · 20 · 25 · 31.3 · 39.1 · 48.8 (px) |
+| `--letter-spacing-tight` | `tracking/tight` | `-0.01em` |
+| `--letter-spacing-wide` | `tracking/wide` | `0.08em` |
+| `--letter-spacing-caps` | `tracking/caps` | `0.14em` *(the mono-caps look)* |
+| `--font-serif` | text style `Display / EB Garamond` | EB Garamond 400–800 |
+| `--font-mono` | text style `Meta / Courier Prime` | Courier Prime 400/700 |
+
+Scale is a Major Third (1.25) off a 20px body. Build text styles in
+pairs that already encode the register: **Display** (EB Garamond,
+tight tracking, large) for headlines and prose; **Meta** (Courier
+Prime, `tracking/caps`, uppercase) for kickers, folios, banners, and
+the JP subtitles.
+
+## What does NOT map — and must not be faked
+
+### The adaptive accent system (`accents.ts` + `IssueAccent.css`)
+
+An issue declares **one** base accent hex. CSS then derives five tones
+from it with OKLCH relative-colour math:
+
+```
+--issue-accent-strong:  oklch(from base  calc(l * 0.78 + lift)  c          h)
+--issue-accent-muted:   oklch(from base  calc(l * 1.15 + lift)  calc(c*.45) h)
+--issue-accent-whisper: oklch(from base  calc(0.97 + lift*.1)   calc(c*.2)  h)
+--issue-accent-ink:     oklch(from base  calc(0.18 + lift*.2)   calc(c*.4)  h)
+```
+
+…and bends every tone again per paper stock (`--issue-accent-lift`:
+ink `+0.18`, kraft `+0.04`, butter `−0.03`, …) and per mode (dark
+`+0.08`, `prefers-contrast: more` pulls chroma back).
+
+**Figma variables cannot do this.** They store values and swap by mode;
+they cannot run `calc()` on a referenced colour's lightness. Any
+attempt to hand-key the five tones into Figma produces stale,
+per-issue swatches that drift from what the build actually renders.
+
+So the boundary is firm:
+- **Mirror the inputs.** Build the nine named seeds from `INK_SEEDS`
+  as flat reference swatches — `accent-seed/tomato #E24E1B`,
+  `accent-seed/brick #9E3A2B`, `accent-seed/cobalt #1D4E89`,
+  `accent-seed/pool #4FB5C8`, `accent-seed/ivy #2E4A2E`,
+  `accent-seed/olive #6B7A3D`, `accent-seed/amethyst #6B5B95`,
+  `accent-seed/oxblood #5E2328`, `accent-seed/coffee #6B4E3D`,
+  `accent-seed/graphite #3F3D3A`. These are the *choices a curator
+  makes*, so they're worth having on the canvas.
+- **Don't mirror the tones.** The derived `strong/muted/whisper/ink`
+  stay CSS-only. If you need to *see* them in a comp, paste the
+  computed values out of the running dev build (DevTools → computed
+  `--issue-accent-strong` on the spread root) into a clearly-labelled
+  **"reference only, non-canonical"** group — and delete it before the
+  file gets reused.
+
+### Motion
+
+Per [`figma-motion.md`](./figma-motion.md): motion is authored
+per-issue when genuinely needed, and `accents.ts` deliberately keeps
+motion *out* of the palette system. Nothing about motion belongs in
+the variable mirror.
+
+## Two useful moves Figma *can* do
+
+### 1. Paper stock as a variable mode
+
+Make a small second collection — **Ground** — with one variable,
+`surface/page`, and a mode per stock: `ivory`, `cream`, `butter`,
+`kraft`, `ink`. Flipping the mode reskins a whole comp's ground in one
+click, which is exactly the "does this spread hold on butter vs.
+kraft?" question you want to answer before building. This is honest
+because `surface/page` is a *flat* stock hex — no lift math involved.
+(Set text colour by hand when you flip to `ink`; the lift adaptation
+that CSS does automatically is not reproduced here, and that's fine for
+a sketch.)
+
+### 2. Candidate-accent preview, the right way
+
+To audition a new seed before committing it to `INK_SEEDS`:
+1. Drop the candidate hex as a temporary `accent-seed/_candidate`
+   swatch.
+2. Lay it on `surface/page` across the five stock modes (move #1).
+3. Judge only the **base** on each ground — chroma warmth, whether it
+   reads as magazine-register or tips into neon/digital (the
+   `isPopeyeSafe()` guardrail).
+4. If it survives, the real validation is still the dev build: add it
+   to `accents.ts`, let the OKLCH derivation + `isPopeyeSafe()` run,
+   and check the five tones on a real spread. **Figma narrows the
+   field; the build makes the call.**
+
+## Hard "do nots"
+
+Carried from the figma-motion MCP note — same reasoning, same teeth:
+
+- **No `get_code`.** It emits React + Tailwind, both off-policy here.
+  Use `get_variable_defs` and `get_image`; read Dev Mode only for
+  measurements.
+- **No Figma Make / Sites codegen, no Tailwind/component export, no
+  Lottie.** The file produces *measurements and decisions*, never code.
+- **The repo is canonical.** When a token changes, change it in
+  `tokens/*.css` first, then update the Figma variable to match —
+  never the other way. The mirror follows the code.
+
+## Setup (local only)
+
+The live Figma↔Claude link needs a **local** Claude Code session on the
+same machine as Figma desktop (a remote/web session's `127.0.0.1` is a
+cloud container, not your Mac):
+
+1. Figma desktop → enable **Dev Mode MCP Server** in preferences
+   (serves at `http://127.0.0.1:3845/mcp`).
+2. `claude mcp add --transport http figma http://127.0.0.1:3845/mcp`
+3. Prefer `get_variable_defs` (read the variable mirror back as
+   token names) and `get_image` (see the comp). Transcribe to CSS by
+   hand.
+
+## The standing rule
+
+> Mirror the static tokens; never the derived ones. Figma sketches the
+> magazine in its own grammar so the comp is honest — then the work is
+> rebuilt in CSS, which stays the single source of truth. A drafting
+> table, not a press.
+
+See also: [`figma-motion.md`](./figma-motion.md),
+[`design-language.md`](./design-language.md), the `kernel-chat-design`
+skill's `tokens/`, and `src/components/IssueAccent.css`.


### PR DESCRIPTION
## What

Figma shipped a product literally named **"Figma Motion"** at Config 2026 (announced 2026-06-24) — a native canvas timeline that keyframes position/scale/rotation/opacity and exports to **CSS / JSON / React / video**. The name collides with `motion.dev` / **Framer Motion**, the JS runtime library already banned by [`design-language.md`](../blob/main/docs/design-language.md) ambient-motion rule 3.

This PR adds `docs/figma-motion.md` to draw the line **before** the collision quietly erodes the motion contract.

## The decision

> Figma Motion may author. Only CSS ships.

- ✅ **Allowed:** Figma Motion as an authoring/spec surface; its **CSS export** may reach the repo — but only as a *draft* run through a hand-finish checklist (re-clamp to ≤8% opacity / ≤4px translate, guard via `prefers-reduced-motion`, `opacity`+`transform` only, strip any JS rider, run the third-accent audit).
- ❌ **Off-policy:** React / `motion.dev`, Lottie / dotLottie, and any runtime-player output — they ship JS and break the CSS-only rule.

The standing rule is **unchanged**: stillness with two quiet accents (tomato-rule breath, dateline marquee), CSS-only, reduced-motion-respected. A slicker authoring tool is not a license to loosen it.

## Why a doc and not code

There's no code change to make — the value is preventing one. The new Figma Motion product makes JS-runtime motion *cheap to author and paste*, which is exactly the pressure the design language was written to resist. This note makes the boundary explicit and gives a concrete checklist for anyone tempted to paste a Figma export.

## Provenance

Sourced from a deep-research pass over Figma's own blog/release notes, TechCrunch, motion.dev, LottieFiles, and 2026 tool comparisons. Key claims (Figma Motion = native timeline w/ CSS export, open beta, design-system features paywalled; Framer Motion = the banned JS lib) verified against primary Figma docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJZDBwNnZjANtKFogEQHwu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJZDBwNnZjANtKFogEQHwu)_