### PR TITLE
fix(site): site-audit remediation — QA/design + P0/P1 security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Design adherence — no raw hex in the editorial design-system layer
         run: npm run lint:adherence
       - run: npx tsc --noEmit
+      - name: Unit tests (root vitest — 498 tests)
+        run: npx vitest run
       - run: npm run build
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -2,6 +2,57 @@
 
 > This file persists context between Claude Code sessions.
 
+## Session 2026-07-09 — Verified a cross-agent routing plan; found `--model opus` broken
+
+Second application of [[feedback_verify_cross_agent_claims]], and it
+caught a *different* failure mode than 2026-07-08. A pasted analysis
+(same parallel Antigravity/Gemini session) proposed a two-rooms workflow:
+local Ollama for the pressroom, Fable 5 for the editor's chair. Verified
+piece by piece:
+
+- **True:** the uncommitted `auth.ts` routing diff. Every model it adds
+  (`gemma4:latest`, `gemma4:31b`, `qwen3:8b`) is genuinely installed —
+  confirmed against `ollama list`. Unlike yesterday, no hallucinated
+  weights. Also correctly moves the Hermes gateway to port 8642.
+- **False:** the commands. `kbot --provider ollama` does not exist —
+  there is no `--provider` root option; provider lives in config as
+  `byok_provider`, set via `kbot byok` / `kbot auth` / `--ollama-launch`.
+- **False:** "gemma4 routes general tasks to Google's Gemma 4." Ollama
+  runs locally; nothing reaches Google. The tok/s and "80–90% savings"
+  numbers appear nowhere in the repo — unverified.
+
+Chasing whether `--model opus` was a valid flag surfaced a real bug:
+`resolveModelAlias()` handled only `fable`, so `opus` fell through
+`isExplicitModel` (agent.ts:1626) and was sent to the Anthropic API as
+the literal string `"opus"` — a 404. Shell completions had been
+suggesting it all along. Fixed via a `FLAGSHIP_ALIASES` table; added 8
+tests (the function had zero), one asserting every resolved ID is a
+member of that provider's `models` catalog. Note `isExplicitModel` is an
+allowlist of *speed hints*, not of models, so any unrecognized alias
+fails at the API boundary rather than at parse time.
+
+Shipped as two commits on `main` (routing first, then the alias fix),
+fast-forwarded from `fix/kbot-model-alias`. Not pushed.
+
+**Do not repeat my mistake:** running `npx vitest run packages/kbot`
+from the repo root looks like a red suite (11 files / 6 tests failing).
+It is not. The root `vitest.config.ts` sets `environment: 'jsdom'`
+globally and lacks kbot's excludes; `packages/kbot/vitest.config.ts`
+sets `environment: 'node'` and excludes `gamedev.test.ts`. The correct
+invocation is `cd packages/kbot && npm test`, which is **green: 70
+files, 1288 tests**. I wrongly reported a red default branch and started
+a bisect before an A/B on `--environment node` disproved it. There is no
+regression and no vitest-version problem (4.0.18 vs installed 4.1.0 both
+pass under the right environment).
+
+Also killed three stale `peekaboo mcp` servers (PIDs 23188/30880/33813)
+left by Tuesday Claude Code sessions, burning 12–18 min CPU each, while
+chasing a phantom-mouse-click report. No evidence they were the cause —
+peekaboo's session log was empty and the kbot daemon has been dead since
+April 19. Cause still unknown; the discriminator is whether clicking
+persists at the macOS login window (no agents run there). Antigravity's
+claim that it restored `ForceSuppressed = 0` on the trackpad checked out.
+
 ## Session 2026-07-08 — Caught hallucinated "local Fable 5" models in kbot routing
 
 A cross-agent workflow surfaced a problem worth remembering: a

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "react-dom": "^19.2.4",
                 "react-i18next": "^16.5.4",
                 "react-markdown": "^10.1.0",
-                "react-router-dom": "^7.13.1",
+                "react-router-dom": "^7.18.1",
                 "zustand": "^5.0.11"
             },
             "devDependencies": {
@@ -11265,9 +11265,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.13.1",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-            "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+            "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -11287,12 +11287,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.13.1",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-            "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+            "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.13.1"
+                "react-router": "7.18.1"
             },
             "engines": {
                 "node": ">=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,37 +3718,30 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -3764,9 +3757,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+            "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@puppeteer/browsers": {
@@ -10965,24 +10958,23 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "react-dom": "^19.2.4",
         "react-i18next": "^16.5.4",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.18.1",
         "zustand": "^5.0.11"
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "overrides": {
         "undici": "^7.24.6",
         "serialize-javascript": "^7.0.5",
-        "xml2js": "^0.6.2"
+        "xml2js": "^0.6.2",
+        "protobufjs": "^7.6.5"
     },
     "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/kbot/src/auth.test.ts
+++ b/packages/kbot/src/auth.test.ts
@@ -18,6 +18,7 @@ import {
   isProviderConfigured,
   isProviderReachable,
   getProviderKey,
+  resolveModelAlias,
   PROVIDERS,
 } from './auth.js'
 
@@ -340,5 +341,37 @@ describe('Anthropic model capabilities', () => {
       const reachable = await isProviderReachable('openai')
       expect(reachable).toBe(true)
     })
+  })
+})
+
+describe('resolveModelAlias', () => {
+  it.each([
+    ['anthropic', 'fable', 'claude-fable-5'],
+    ['anthropic', 'opus', 'claude-opus-4-8'],
+    ['openrouter', 'fable', 'anthropic/claude-fable-5'],
+    ['openrouter', 'opus', 'anthropic/claude-opus-4-8'],
+  ] as const)('resolves %s alias %s', (provider, alias, expected) => {
+    expect(resolveModelAlias(provider, alias)).toBe(expected)
+  })
+
+  // A resolved alias that isn't in the provider's catalog would 404 at call time.
+  it.each(['fable', 'opus'] as const)('resolves %s to a model the provider carries', (alias) => {
+    for (const provider of ['anthropic', 'openrouter'] as const) {
+      expect(PROVIDERS[provider].models).toContain(resolveModelAlias(provider, alias))
+    }
+  })
+
+  it('passes through full model IDs unchanged', () => {
+    expect(resolveModelAlias('anthropic', 'claude-opus-4-8')).toBe('claude-opus-4-8')
+  })
+
+  it('passes through aliases the provider does not carry', () => {
+    expect(resolveModelAlias('ollama', 'opus')).toBe('opus')
+  })
+
+  // agent.ts consumes these as speed hints; resolving them here would promote
+  // them to explicit overrides and bypass cost-aware routing.
+  it.each(['sonnet', 'haiku', 'auto', 'fast', 'default'])('leaves the speed hint %s alone', (hint) => {
+    expect(resolveModelAlias('anthropic', hint)).toBe(hint)
   })
 })

--- a/packages/kbot/src/auth.ts
+++ b/packages/kbot/src/auth.ts
@@ -23,7 +23,7 @@ const LMSTUDIO_HOST = process.env.LMSTUDIO_HOST || 'http://localhost:1234'
 const JAN_HOST = process.env.JAN_HOST || 'http://localhost:1337'
 const KBOT_LOCAL_HOST = process.env.KBOT_LOCAL_HOST || 'http://127.0.0.1:18789'
 const LLADA_HOST = process.env.KBOT_LLADA_URL || 'http://localhost:8000'
-const HERMES_HOST = process.env.HERMES_HOST || 'http://localhost:8000'
+const HERMES_HOST = process.env.HERMES_HOST || 'http://127.0.0.1:8642'
 
 // ── All supported providers ──
 
@@ -265,8 +265,8 @@ export const PROVIDERS: Record<ByokProvider, ProviderConfig> = {
     name: 'Ollama (Local)',
     apiUrl: `${OLLAMA_HOST}/v1/chat/completions`,
     apiStyle: 'openai',
-    defaultModel: 'gemma3:12b',
-    fastModel: 'qwen2.5-coder:7b',
+    defaultModel: 'gemma4:latest',
+    fastModel: 'qwen3:8b',
     inputCost: 0,
     outputCost: 0,
     authHeader: 'bearer',  // Ollama ignores auth but needs valid header
@@ -304,8 +304,10 @@ export const PROVIDERS: Record<ByokProvider, ProviderConfig> = {
     // OpenAI-compatible HTTP API server (see hermes-agent.nousresearch.com).
     // kbot uses Hermes as a delegate: kbot orchestrates; Hermes executes
     // long-form research and skill-heavy workflows where its mature skill
-    // system is the better fit. Run locally via `hermes gateway` (default
-    // port 8000) or override via HERMES_HOST env var.
+    // system is the better fit. The API server is a gateway "platform" that
+    // is OFF by default — set API_SERVER_ENABLED=true (and API_SERVER_KEY)
+    // in ~/.hermes/.env, then run `hermes gateway run`. Default port is
+    // 8642, not Hermes' other services' 8000; override via HERMES_HOST.
     name: 'Hermes Agent (Local)',
     apiUrl: `${HERMES_HOST}/v1/chat/completions`,
     apiStyle: 'openai',
@@ -596,8 +598,8 @@ export function getProvider(provider: ByokProvider): ProviderConfig {
 /** Ollama model routing — pick the best local model for the task */
 const OLLAMA_MODEL_ROUTES: Array<{ keywords: RegExp; models: string[]; fallbackCategory: 'code' | 'reasoning' | 'general' }> = [
   { keywords: /\b(code|function|class|refactor|debug|typescript|javascript|python|rust|go|java|html|css|react|vue|angular|api|endpoint|sql|query|database|schema|migration|test|spec|lint|build|compile|import|export|module|package|dependency|npm|pip|cargo)\b/i, models: ['qwen2.5-coder:32b', 'qwen2.5-coder:14b', 'qwen2.5-coder:7b', 'deepseek-coder-v2:16b', 'codellama:13b', 'codegemma:7b', 'starcoder2:7b'], fallbackCategory: 'code' },
-  { keywords: /\b(reason|think|why|explain|analyze|compare|evaluate|proof|logic|math|calculate|solve|deduc|infer|hypothesis|trade.?off|pros?\s+and\s+cons?|decision)\b/i, models: ['deepseek-r1:32b', 'deepseek-r1:14b', 'deepseek-r1:7b', 'phi4:14b', 'gemma3:27b', 'gemma3:12b', 'qwen2.5:32b', 'mistral:7b'], fallbackCategory: 'reasoning' },
-  { keywords: /\b(research|search|find|look\s+up|summarize|article|paper|report|review|document|write|blog|essay|draft|outline|rewrite|edit|proofread)\b/i, models: ['llama3.3:70b', 'qwen2.5:72b', 'gemma3:27b', 'gemma3:12b', 'llama3.1:8b', 'mistral:7b'], fallbackCategory: 'general' },
+  { keywords: /\b(reason|think|why|explain|analyze|compare|evaluate|proof|logic|math|calculate|solve|deduc|infer|hypothesis|trade.?off|pros?\s+and\s+cons?|decision)\b/i, models: ['deepseek-r1:32b', 'deepseek-r1:14b', 'deepseek-r1:7b', 'phi4:14b', 'gemma4:31b', 'gemma4:latest', 'gemma3:27b', 'gemma3:12b', 'qwen2.5:32b', 'mistral:7b'], fallbackCategory: 'reasoning' },
+  { keywords: /\b(research|search|find|look\s+up|summarize|article|paper|report|review|document|write|blog|essay|draft|outline|rewrite|edit|proofread)\b/i, models: ['llama3.3:70b', 'qwen2.5:72b', 'gemma4:31b', 'gemma4:latest', 'gemma3:27b', 'gemma3:12b', 'llama3.1:8b', 'mistral:7b'], fallbackCategory: 'general' },
 ]
 
 /** Cache of available Ollama models (refreshed periodically) */
@@ -642,7 +644,7 @@ export function selectOllamaModel(message: string, availableModels?: string[]): 
     }
   }
   // No keyword match — prefer the largest available model
-  const preferredFallbacks = ['gemma3:27b', 'phi4:14b', 'gemma3:12b', 'deepseek-r1:14b', 'qwen2.5-coder:14b', 'mistral:7b', 'llama3.1:8b']
+  const preferredFallbacks = ['gemma4:31b', 'gemma4:latest', 'gemma3:27b', 'phi4:14b', 'gemma3:12b', 'deepseek-r1:14b', 'qwen3:8b', 'qwen2.5-coder:14b', 'mistral:7b', 'llama3.1:8b']
   for (const model of preferredFallbacks) {
     if (isModelAvailable(model, available)) return model
   }

--- a/packages/kbot/src/auth.ts
+++ b/packages/kbot/src/auth.ts
@@ -1279,17 +1279,21 @@ export function anthropicThinkingConfig(
     : { type: 'enabled', budget_tokens: budgetTokens }
 }
 
+// `sonnet` and `haiku` are deliberately absent: agent.ts treats them as speed
+// hints and resolves them through getProviderModel(). Adding them here would
+// promote them to explicit-model overrides and bypass cost-aware routing.
+const FLAGSHIP_ALIASES: Record<string, Partial<Record<ByokProvider, string>>> = {
+  fable: { anthropic: 'claude-fable-5', openrouter: 'anthropic/claude-fable-5' },
+  opus: { anthropic: 'claude-opus-4-8', openrouter: 'anthropic/claude-opus-4-8' },
+}
+
 /**
  * Resolve a short flagship alias to the provider's full model ID. Lets users
  * pass `--model fable` the way they already pass `claude-fable-5`. Returns the
  * input unchanged when it isn't a known alias or the provider doesn't carry it.
  */
 export function resolveModelAlias(provider: ByokProvider, model: string): string {
-  if (model === 'fable') {
-    if (provider === 'anthropic') return 'claude-fable-5'
-    if (provider === 'openrouter') return 'anthropic/claude-fable-5'
-  }
-  return model
+  return FLAGSHIP_ALIASES[model]?.[provider] ?? model
 }
 
 export { KBOT_DIR, CONFIG_PATH, ENV_KEYS }

--- a/packages/kbot/src/cli.ts
+++ b/packages/kbot/src/cli.ts
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
     .description('kbot — Open-source terminal AI agent. Bring your own key, pick your model, run locally.')
     .version(VERSION)
     .option('-a, --agent <agent>', 'Force a specific agent (run kbot agents to see all 35)')
-    .option('-m, --model <model>', 'Override AI model (auto, sonnet, haiku)')
+    .option('-m, --model <model>', 'Override AI model (auto, fable, opus, sonnet, haiku, or a full model ID)')
     .option('-s, --stream', 'Stream the response')
     .option('-p, --pipe', 'Pipe mode — raw text output for scripting')
     .option('--json', 'JSON output for scripting')

--- a/packages/kbot/src/completions.ts
+++ b/packages/kbot/src/completions.ts
@@ -197,7 +197,7 @@ _kbot_completions() {
       return
       ;;
     --model|-m)
-      COMPREPLY=( $(compgen -W "auto fable sonnet haiku opus gpt-4o gpt-4o-mini gemini-pro" -- "\${cur}") )
+      COMPREPLY=( $(compgen -W "auto fable sonnet haiku opus" -- "\${cur}") )
       return
       ;;
     --resume)
@@ -292,7 +292,7 @@ _kbot() {
 
   global_opts=(
     '(-a --agent)'{-a,--agent}'[Force a specific agent]:agent:(${AGENT_NAMES.join(' ')})'
-    '(-m --model)'{-m,--model}'[Override AI model]:model:(auto fable sonnet haiku opus gpt-4o gpt-4o-mini gemini-pro)'
+    '(-m --model)'{-m,--model}'[Override AI model]:model:(auto fable sonnet haiku opus)'
     '(-s --stream)'{-s,--stream}'[Stream the response]'
     '(-p --pipe)'{-p,--pipe}'[Pipe mode for scripting]'
     '--json[JSON output for scripting]'
@@ -468,7 +468,7 @@ function generateFish(): string {
 
   lines.push('')
   lines.push('# Model names for --model')
-  const models = ['auto', 'fable', 'sonnet', 'haiku', 'opus', 'gpt-4o', 'gpt-4o-mini', 'gemini-pro']
+  const models = ['auto', 'fable', 'sonnet', 'haiku', 'opus']
   for (const model of models) {
     lines.push(`complete -c kbot -n '__fish_seen_argument -l model -s m' -a '${model}'`)
   }

--- a/src/components/CloseFeature.css
+++ b/src/components/CloseFeature.css
@@ -379,6 +379,40 @@
   }
 }
 
+/* ── Ink stock — flip prose colors for dark paper ──────────
+   ISSUE 415 ships on the ink stock (spread.stock = 'ink'), the
+   dark register 371 used for its own dispatch. The title, prose,
+   headings, byline, readout, notes, and signoff monument all
+   default to ink-dark tones (via .pop-display / .pop-monument /
+   var(--pop-ink) / var(--pop-coffee)) that vanish against the ink
+   ground — a class-level color beats the ivory the .pop-stock-ink
+   container tries to inherit down. Flip each to ivory/sepia.
+   The spec frame, the simulated feed, and the two controls each
+   sit on their own ivory card, so their interior ink/coffee text
+   is already legible and is deliberately left untouched. Mirrors
+   the ink-override block in EssayFeature.css. */
+.pop-close.pop-stock-ink .pop-close-title { color: var(--pop-ivory); }
+.pop-close.pop-stock-ink .pop-close-title-jp { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-deck { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-byline { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-prose { color: var(--pop-ivory); }
+.pop-close.pop-stock-ink .pop-close-section-heading { color: var(--pop-ivory); }
+.pop-close.pop-stock-ink .pop-close-section-heading-jp { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-readout { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-apparatus-kicker { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-tally-note { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-signoff-text { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-pullquote-cite { color: var(--pop-sepia); }
+.pop-close.pop-stock-ink .pop-close-monument { color: var(--pop-ivory); }
+
+/* Dividers default to the dark ink hairline; lift them to a
+   translucent ivory so they read on the dark ground. */
+.pop-close.pop-stock-ink {
+  border-top-color: rgba(250, 249, 246, 0.16);
+  border-bottom-color: rgba(250, 249, 246, 0.16);
+}
+.pop-close.pop-stock-ink .pop-close-rule { background: rgba(250, 249, 246, 0.16); }
+
 @media (max-width: 640px) {
   .pop-close { padding: 56px 0; }
   .pop-close-inner { padding: 0 22px; }

--- a/src/components/CloseFeature.test.tsx
+++ b/src/components/CloseFeature.test.tsx
@@ -23,7 +23,7 @@ const issue: IssueRecord = {
   feature: 'STOP PRESS',
   featureJp: '終わりの合図',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
   headline: { prefix: 'Stop', emphasis: 'Press', suffix: '.', swash: '' },
   contents: [],
   spread,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,50 @@
+import { useEffect } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { motion, AnimatePresence } from 'motion/react'
 import { TRANSITION } from '../constants/motion'
+import { findIssue } from '../content/issues'
+
+const BASE_TITLE = 'kernel.chat — Magazine for City Coders'
+
+/**
+ * Per-route browser title, in the magazine's own vocabulary
+ * (issue / feature / archive / pressroom / colophon — never
+ * dashboard/panel). Issue routes resolve the feature name from
+ * the synchronously-imported content index via findIssue(), so the
+ * title is rich even before the lazy page chunk loads.
+ */
+function titleForPath(pathname: string): string {
+  const [head, param, sub] = pathname.split('/').filter(Boolean)
+  if (!head) return BASE_TITLE
+
+  const issueLabel = (n?: string) => {
+    const issue = n ? findIssue(n) : undefined
+    return issue ? `Issue ${issue.number} — ${issue.feature}` : `Issue ${n ?? ''}`.trim()
+  }
+
+  switch (head) {
+    case 'issues':
+      if (!param) return 'The Archive · kernel.chat'
+      return sub === 'back'
+        ? `${issueLabel(param)} · Back Cover · kernel.chat`
+        : `${issueLabel(param)} · kernel.chat`
+    case 'launch':
+      return `${issueLabel(param)} · Launch · kernel.chat`
+    case 'refusals': return 'Refusals · kernel.chat'
+    case 'pressroom': return 'The Pressroom · kernel.chat'
+    case 'about': return 'About · kernel.chat'
+    case 'privacy': return 'Privacy · kernel.chat'
+    case 'terms': return 'Terms · kernel.chat'
+    default: return BASE_TITLE
+  }
+}
 
 export function Layout() {
   const location = useLocation()
+
+  useEffect(() => {
+    document.title = titleForPath(location.pathname)
+  }, [location.pathname])
 
   return (
     <div className="site-wrapper">

--- a/src/components/MagazineFrame.tsx
+++ b/src/components/MagazineFrame.tsx
@@ -116,7 +116,7 @@ export function MagazineFrame({
           <hr className="pop-rule pop-rule--soft" />
           <div className="pop-frame-row pop-frame-footer-row">
             <span className="pop-folio">
-              {ISSUE.tagline}
+              {issue.tagline}
             </span>
             <div className="pop-frame-footer-actions">
               <button
@@ -135,7 +135,7 @@ export function MagazineFrame({
             </div>
             <span className="pop-folio">
               <PopIcon name="asterisk" size="sm" className="pop-system-glyph" />
-              ISSUE {ISSUE.number} · {ISSUE.month} {ISSUE.year}
+              ISSUE {issue.number} · {issue.month} {issue.year}
             </span>
           </div>
         </div>

--- a/src/content/issues/386.ts
+++ b/src/content/issues/386.ts
@@ -48,7 +48,7 @@ export const ISSUE_386: IssueRecord = {
   feature: 'ON THE FIELD',
   featureJp: '「分野について」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/387.ts
+++ b/src/content/issues/387.ts
@@ -42,7 +42,7 @@ export const ISSUE_387: IssueRecord = {
   feature: 'ON ORCHESTRATION',
   featureJp: '「オーケストレーションについて」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/388.ts
+++ b/src/content/issues/388.ts
@@ -53,7 +53,7 @@ export const ISSUE_388: IssueRecord = {
   feature: 'ON THE BRANCH',
   featureJp: '「分岐について」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/389.ts
+++ b/src/content/issues/389.ts
@@ -53,7 +53,7 @@ export const ISSUE_389: IssueRecord = {
   feature: 'ON SURPASSING',
   featureJp: '「超えることについて」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/390.ts
+++ b/src/content/issues/390.ts
@@ -52,7 +52,7 @@ export const ISSUE_390: IssueRecord = {
   feature: 'ON THE CONSUMER STANDARD',
   featureJp: '「消費者標準について」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/391.ts
+++ b/src/content/issues/391.ts
@@ -42,7 +42,7 @@ export const ISSUE_391: IssueRecord = {
   feature: 'ON THE HOUSE STYLE',
   featureJp: '「ハウススタイルについて」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'classic',

--- a/src/content/issues/394.ts
+++ b/src/content/issues/394.ts
@@ -41,7 +41,7 @@ export const ISSUE_394: IssueRecord = {
   feature: 'THE QUIET RESCUES',
   featureJp: '「静かな救助」',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'classic',

--- a/src/content/issues/395.ts
+++ b/src/content/issues/395.ts
@@ -49,12 +49,12 @@ import type { IssueRecord } from './index'
 
 export const ISSUE_395: IssueRecord = {
   number: '395',
-  month: 'MAY',
+  month: 'JUN',
   year: '2026',
   feature: 'THE WEEK THE ASSISTANT BECAME AN ACTOR',
   featureJp: '助手が動き手になった週',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/396.ts
+++ b/src/content/issues/396.ts
@@ -62,7 +62,7 @@ export const ISSUE_396: IssueRecord = {
   feature: 'THE PRICE OF THINKING',
   featureJp: '思考の値段',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ledger',
   coverLayout: 'classic',

--- a/src/content/issues/397.ts
+++ b/src/content/issues/397.ts
@@ -56,7 +56,7 @@ export const ISSUE_397: IssueRecord = {
   feature: 'THE EIGHTEEN DAYS',
   featureJp: '十八日間',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ink',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/398.ts
+++ b/src/content/issues/398.ts
@@ -53,7 +53,7 @@ export const ISSUE_398: IssueRecord = {
   feature: 'NO MORE QUESTIONS',
   featureJp: '問いはもう無い',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ink',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/399.ts
+++ b/src/content/issues/399.ts
@@ -57,7 +57,7 @@ export const ISSUE_399: IssueRecord = {
   feature: 'HOW HARD TO THINK',
   featureJp: '思考の深さ',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'classic',

--- a/src/content/issues/400.ts
+++ b/src/content/issues/400.ts
@@ -47,7 +47,7 @@ export const ISSUE_400: IssueRecord = {
   feature: 'THE FOUR HUNDRED',
   featureJp: '四百号',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'monument-hero',

--- a/src/content/issues/401.ts
+++ b/src/content/issues/401.ts
@@ -45,7 +45,7 @@ export const ISSUE_401: IssueRecord = {
   feature: 'THE GREEN DOT',
   featureJp: '緑の点',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/402.ts
+++ b/src/content/issues/402.ts
@@ -49,7 +49,7 @@ export const ISSUE_402: IssueRecord = {
   feature: 'THE WRONG ROOM',
   featureJp: '間違った部屋',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'kraft',
   coverLayout: 'classic',

--- a/src/content/issues/403.ts
+++ b/src/content/issues/403.ts
@@ -52,7 +52,7 @@ export const ISSUE_403: IssueRecord = {
   feature: 'THE READER’S HAND',
   featureJp: '読者の手',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'butter',
   coverLayout: 'numbered-catalog',

--- a/src/content/issues/404.ts
+++ b/src/content/issues/404.ts
@@ -46,7 +46,7 @@ export const ISSUE_404: IssueRecord = {
   feature: 'THE LOCKSMITH’S ROUNDS',
   featureJp: '錠前屋の巡回',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ledger',
   coverLayout: 'ledger-rule',

--- a/src/content/issues/405.ts
+++ b/src/content/issues/405.ts
@@ -66,7 +66,7 @@ export const ISSUE_405: IssueRecord = {
   feature: 'THE REAL METER',
   featureJp: '本物の計器',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ink',
   coverLayout: 'classic',

--- a/src/content/issues/406.ts
+++ b/src/content/issues/406.ts
@@ -63,7 +63,7 @@ export const ISSUE_406: IssueRecord = {
   feature: 'ONE DAY, TWO READINGS',
   featureJp: '一日、二つの読み方',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'butter',
   coverLayout: 'classic',

--- a/src/content/issues/407.ts
+++ b/src/content/issues/407.ts
@@ -62,7 +62,7 @@ export const ISSUE_407: IssueRecord = {
   feature: 'WHAT THE HAND EARNED',
   featureJp: '手が得たもの',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'classic',

--- a/src/content/issues/408.ts
+++ b/src/content/issues/408.ts
@@ -66,7 +66,7 @@ export const ISSUE_408: IssueRecord = {
   feature: 'THE LOOP THAT KNOWS WHEN TO STOP',
   featureJp: '止まり方を知るループ',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'classic',

--- a/src/content/issues/409.ts
+++ b/src/content/issues/409.ts
@@ -80,7 +80,7 @@ export const ISSUE_409: IssueRecord = {
   feature: 'NO METER FOR FEELING',
   featureJp: '感情の計器は無い',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ink',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/410.ts
+++ b/src/content/issues/410.ts
@@ -103,7 +103,7 @@ export const ISSUE_410: IssueRecord = {
   feature: "THE EDITOR'S KNIFE",
   featureJp: '編集者のナイフ',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'kraft',
   coverLayout: 'classic',

--- a/src/content/issues/411.ts
+++ b/src/content/issues/411.ts
@@ -91,7 +91,7 @@ export const ISSUE_411: IssueRecord = {
   feature: 'OPERATING INSTRUCTIONS',
   featureJp: '取扱説明書',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'butter',
   coverLayout: 'classic',

--- a/src/content/issues/412.ts
+++ b/src/content/issues/412.ts
@@ -91,7 +91,7 @@ export const ISSUE_412: IssueRecord = {
   feature: 'THE MARGIN',
   featureJp: '余白',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'cream',
   coverLayout: 'classic',

--- a/src/content/issues/413.ts
+++ b/src/content/issues/413.ts
@@ -87,7 +87,7 @@ export const ISSUE_413: IssueRecord = {
   feature: "THE READER'S PRESS",
   featureJp: '読者の印刷機',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ledger',
   coverLayout: 'classic',

--- a/src/content/issues/414.ts
+++ b/src/content/issues/414.ts
@@ -82,7 +82,7 @@ export const ISSUE_414: IssueRecord = {
   feature: 'RECEIPTS, NOT RATINGS',
   featureJp: '評価ではなく証跡を',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ivory',
   coverLayout: 'asymmetric-left',

--- a/src/content/issues/415.ts
+++ b/src/content/issues/415.ts
@@ -62,7 +62,7 @@ export const ISSUE_415: IssueRecord = {
   feature: 'STOP PRESS',
   featureJp: '終わりの合図',
   price: '¥0 · BYOK',
-  tagline: 'MAGAZINE OF AGENTIC ENGINEERING · エージェント工学の雑誌',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
 
   coverStock: 'ink',
   coverLayout: 'monument-hero',

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -82,7 +82,9 @@ export function useAuth(): AuthState {
 
     const pendingRecovery = localStorage.getItem(RECOVERY_FLAG);
 
-    console.log('[Auth] init — code:', hasCode, 'error:', hasError, 'tokenHash:', !!tokenHash, 'pendingRecovery:', !!pendingRecovery, 'url:', window.location.href);
+    // Log only boolean state — never the full URL, which carries the
+    // recovery `token_hash` (and could reach logs/telemetry).
+    console.log('[Auth] init — code:', hasCode, 'error:', hasError, 'tokenHash:', !!tokenHash, 'pendingRecovery:', !!pendingRecovery);
 
     if (hasError) {
       console.warn('[Auth] OAuth error:', params.get('error'), params.get('error_description'));

--- a/src/index.css
+++ b/src/index.css
@@ -152,8 +152,12 @@
     --pop-ink:      #1F1E1D;   /* = rubin-slate */
 
     /* Spot colors — the punch accents */
-    --pop-tomato:   #E24E1B;   /* THE Popeye accent — banners, rules, tags */
+    --pop-tomato:   #E24E1B;   /* THE Popeye accent — rules, tags, em */
     --pop-tomato-soft: rgba(226, 78, 27, 0.08);
+    --pop-tomato-deep: #C63D14; /* AA-safe banner red: ivory text ≈ 4.98:1
+                                   vs 3.8:1 on --pop-tomato. Used only where
+                                   small ivory text sits ON the accent, i.e.
+                                   .pop-banner. Not a second brand color. */
 
     /* Reserved issue-variant accents (future "nature" / "city" covers).
        Kept in the palette so a future issue can be re-skinned without

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -25,11 +25,11 @@ function RootErrorPage() {
   const error = useRouteError() as any
   const message = error?.statusText || error?.message || String(error)
   return (
-    <div style={{ padding: 40, fontFamily: 'Courier Prime, monospace', color: '#1F1E1D', background: '#FAF9F6', minHeight: '100vh' }}>
-      <h1 style={{ fontSize: 24, marginBottom: 16 }}>Something went wrong</h1>
-      <pre style={{ whiteSpace: 'pre-wrap', opacity: 0.7, fontSize: 14, marginBottom: 24 }}>{message}</pre>
-      <pre style={{ whiteSpace: 'pre-wrap', opacity: 0.5, fontSize: 12 }}>{error?.stack || JSON.stringify(error, null, 2)}</pre>
-      <button onClick={() => window.location.hash = '#/'} style={{ marginTop: 24, padding: '8px 24px', cursor: 'pointer' }}>
+    <div className="pop-error-page">
+      <h1>Something went wrong</h1>
+      <pre>{message}</pre>
+      <pre className="pop-error-stack">{error?.stack || JSON.stringify(error, null, 2)}</pre>
+      <button onClick={() => window.location.hash = '#/'}>
         Go Home
       </button>
     </div>

--- a/src/styles/editorial.css
+++ b/src/styles/editorial.css
@@ -40,7 +40,7 @@
 .pop-kicker--tomato { color: var(--issue-accent, var(--pop-tomato)); }
 
 /* Tomato banner tag — feature flag style, reversed rounded-corner box */
-.pop-banner { display: inline-block; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--letter-spacing-caps); text-transform: uppercase; background: var(--pop-tomato); color: var(--pop-ivory); padding: 4px 12px; border-radius: 2px; font-weight: 700; }
+.pop-banner { display: inline-block; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--letter-spacing-caps); text-transform: uppercase; background: var(--pop-tomato-deep); color: var(--pop-ivory); padding: 4px 12px; border-radius: 2px; font-weight: 700; }
 .pop-banner--ink { background: var(--pop-ink); color: var(--pop-ivory); }
 .pop-banner--kraft { background: var(--pop-kraft); color: var(--pop-ink); }
 
@@ -161,3 +161,12 @@
 /* Feature-JP micro lockup — small Japanese subtitle */
 .pop-feature-jp { font-family: var(--font-mono); font-size: var(--text-sm); letter-spacing: 0.12em; color: var(--pop-coffee); margin: 0; }
 .pop-section-header--on-ink .pop-feature-jp { color: var(--pop-sepia); }
+
+/* Global router error page — last-resort UI when a route throws. Token-
+   driven so it stays on-brand and honours the no-inline-style/no-raw-hex
+   rules; editorial.css is @imported by index.css, so it is always loaded. */
+.pop-error-page { padding: 40px; font-family: var(--font-mono); color: var(--pop-ink); background: var(--pop-ivory); min-height: 100vh; }
+.pop-error-page h1 { font-size: 24px; margin: 0 0 16px; }
+.pop-error-page pre { white-space: pre-wrap; font-size: 14px; margin: 0 0 24px; opacity: 0.7; }
+.pop-error-page pre.pop-error-stack { font-size: 12px; opacity: 0.5; }
+.pop-error-page button { margin-top: 24px; padding: 8px 24px; font-family: inherit; cursor: pointer; color: var(--pop-ink); background: none; border: 1px solid var(--pop-ink); border-radius: 4px; }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
 import { registerRoute, NavigationRoute } from 'workbox-routing'
-import { NetworkOnly, NetworkFirst, CacheFirst, StaleWhileRevalidate } from 'workbox-strategies'
+import { NetworkOnly, NetworkFirst, CacheFirst } from 'workbox-strategies'
 import { ExpirationPlugin } from 'workbox-expiration'
 
 declare let self: ServiceWorkerGlobalScope
@@ -98,13 +98,13 @@ registerRoute(
   })
 )
 
-// Supabase REST API — stale while revalidate
+// Supabase REST API — NEVER cache. Responses are per-user and gated by a
+// bearer token, but Workbox keys the cache on URL alone, so a cached body
+// could be served across accounts on a shared browser profile and would
+// persist authed data offline. Authenticated REST must always hit network.
 registerRoute(
   /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
-  new StaleWhileRevalidate({
-    cacheName: 'supabase-api',
-    plugins: [new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 300 })],
-  })
+  new NetworkOnly()
 )
 
 // ─── Push notifications ───
@@ -173,6 +173,9 @@ self.addEventListener('activate', (event) => {
       // Clear the JS/CSS cache on activation — content-hashed filenames
       // mean a fresh network fetch will always get the correct version.
       caches.delete('app-code'),
+      // Evict any Supabase REST responses cached by a prior SW version —
+      // that route is now NetworkOnly; this purges the sensitive backlog.
+      caches.delete('supabase-api'),
       // Enable navigation preload — starts fetch in parallel with SW boot
       self.registration.navigationPreload?.enable().catch(() => {}),
     ]).then(() => self.clients.claim())

--- a/supabase/functions/computer-engine/index.ts
+++ b/supabase/functions/computer-engine/index.ts
@@ -139,6 +139,22 @@ serve(async (req: Request) => {
     }
 
     if (action === 'execute') {
+      // ── KILL-SWITCH (P0 security) ────────────────────────────────
+      // In-process execution uses `new Function` (see executeInDeno),
+      // whose body runs in this Edge Function's GLOBAL scope — it can
+      // reach Deno.env (incl. SUPABASE_SERVICE_ROLE_KEY), fetch, and
+      // every runtime global. That is arbitrary code execution beside
+      // production secrets. Disabled by default until execution is moved
+      // to a secret-free, genuinely isolated worker/container. To
+      // re-enable, set the secret COMPUTER_ENGINE_EXEC_ENABLED='true' —
+      // do NOT do so while executeInDeno still relies on `new Function`.
+      if (Deno.env.get('COMPUTER_ENGINE_EXEC_ENABLED') !== 'true') {
+        return new Response(
+          JSON.stringify({ error: 'Code execution is temporarily disabled.', code: 'EXEC_DISABLED' }),
+          { status: 503, headers: { ...CORS, 'Content-Type': 'application/json' } },
+        )
+      }
+
       const { code, language, sandbox_id } = body
       if (!code || !language || !sandbox_id) {
         return new Response(JSON.stringify({ error: 'Missing code, language, or sandbox_id' }), {
@@ -254,6 +270,14 @@ serve(async (req: Request) => {
  * This runs in the Deno edge runtime's sandboxed environment.
  */
 async function executeInDeno(code: string, timeoutMs: number): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // Hard guard (P0): never build `new Function` from caller-supplied code
+  // unless execution has been explicitly re-enabled. Belt-and-suspenders
+  // with the action-level kill-switch above, in case another path ever
+  // reaches this helper.
+  if (Deno.env.get('COMPUTER_ENGINE_EXEC_ENABLED') !== 'true') {
+    return { stdout: '', stderr: 'Code execution is disabled.', exitCode: 1 }
+  }
+
   const logs: string[] = []
   const errors: string[] = []
 

--- a/supabase/migrations/093_lock_shared_conversations_reads.sql
+++ b/supabase/migrations/093_lock_shared_conversations_reads.sql
@@ -1,0 +1,25 @@
+-- Migration 093: Lock down shared_conversations reads (P0 security)
+--
+-- Migration 012 shipped a public SELECT policy with `USING (true)`, which
+-- let anyone holding the anon key enumerate the ENTIRE table — every share's
+-- messages JSON, owner user_id, title, and expiry — without knowing a share
+-- UUID. The share link's UUID gave no confidentiality while full-table
+-- enumeration over the REST API remained possible.
+--
+-- No legitimate client path needs anonymous table access:
+--   • The public share VIEWER reads through the `shared-conversation` edge
+--     function, which uses the service-role key (bypasses RLS), returns a
+--     single share by id, and enforces `expires_at`. That IS the scoped,
+--     validated access path.
+--   • Direct client reads (SupabaseClient.ts) are all owner-scoped:
+--     share-count-today and the "is this conversation already shared?" check.
+--
+-- So: drop the public policy, and let owners read only their own rows.
+
+DROP POLICY IF EXISTS "Public can view shared conversations" ON shared_conversations;
+
+CREATE POLICY "Owners can view their own shared conversations"
+  ON shared_conversations FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- INSERT/DELETE owner policies from migration 012 remain in force.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,24 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/setupTests.ts'],
-    exclude: ['e2e/**', 'node_modules/**', 'legacy/**', '**/node_modules/**', 'packages/kbot/dist/**', 'kernel-chat-site/**'],
+    // This config serves the web app in src/, so it runs under jsdom.
+    // Packages that ship their own vitest config run under environment:'node'
+    // and must not be globbed here — jsdom breaks their builtin-module mocks.
+    // Run those with `npm test` inside the package.
+    // kbot-control-standalone uses `node --test` against dist/, not vitest.
+    // kbot-ableton-extension is deliberately absent: it owns no runner, so
+    // its tests only execute as part of this root suite.
+    exclude: [
+      'e2e/**',
+      'node_modules/**',
+      '**/node_modules/**',
+      'legacy/**',
+      'kernel-chat-site/**',
+      'packages/kbot/**',
+      'packages/kbot-finance/**',
+      'packages/agent-os/**',
+      'packages/kbot-control-standalone/**',
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Response to a full site + repo audit. Cross-agent (Antigravity/Gemini) findings were **independently verified against the code** before acting — every claim here was grep/read-confirmed.

**Verified before merge:** `tsc` clean · design-adherence 0 hex on the system surface · **498/498** root tests · production build · live route smoke (console clean). Prod `npm audit` criticals: **2 → 0**.

## Editorial / QA / design
- **ISSUE 415 body was invisible** (ink-on-ink on the `ink` spread stock). Added a `.pop-close.pop-stock-ink` override block (mirrors `EssayFeature.css`) → prose now ivory on ink ≈ 17:1.
- **Brand convergence** — all 56 issues now read `MAGAZINE FOR CITY CODERS · 街のコーダーのために` (canonical). 28 issues (386→415) had drifted to "Agentic Engineering"; rolled back to the string the other 28 already used.
- **Archive chronology** — ISSUE 395 MAY → JUN 2026 (was out of order between 394/396).
- **Per-route `<title>`** — centralized in `Layout` via `findIssue()`, magazine vocabulary; was one static title everywhere.
- **MagazineFrame footer** used the global latest issue instead of the passed one.
- **Banner contrast** — ivory-on-tomato ≈ 3.8:1 (< AA) → scoped `--pop-tomato-deep` (#C63D14 ≈ 4.98:1); the `--pop-tomato` brand token is untouched.

## Security (verified true)
- **P0 — computer-engine RCE**: `new Function` ran subscriber code in the edge runtime's global scope (reachable: `Deno.env` incl. service-role key). Added an env kill-switch (`COMPUTER_ENGINE_EXEC_ENABLED`, default **off**) + hard guard.
- **P0 — shared_conversations RLS**: public `USING (true)` SELECT let the anon key enumerate the whole table. Migration `093` → owner-only SELECT. Public viewing unaffected (already served by the service-role `shared-conversation` edge fn).
- **P1** — `sw.ts` Supabase REST → `NetworkOnly` + cache purge; `useAuth` no longer logs the URL/`token_hash`; `router.tsx` error page tokenized.
- **Critical RCEs** — react-router-dom 7.13.1 → 7.18.1 (turbo-stream); protobufjs override → 7.6.5 (transitive via PostHog/OTel).
- **CI** — the Web job never ran the 498 root tests; added `npx vitest run`.

## ⚠️ Requires deploy after merge (the two P0s are inert until then)
```bash
npx supabase functions deploy computer-engine --project-ref eoxxpyixdieprsxlpwcs --no-verify-jwt
npx supabase db push   # migration 093
```
The SW/auth/react-router/protobufjs fixes ship with the normal web build.

## Not included (verified backlog, deliberate)
12 high / 19 moderate npm vulns (triage per-advisory) · stale E2E suite (tests the retired chat-at-`/` UX) · 101 page-level hex → tokens · `eslint` absent though `"lint"` references it · ~631 MB git pack · kbot tests write to real `~/.kbot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)