### PR TITLE
Open THE ATELIER — the made-to-order desk at /atelier

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -2,6 +2,34 @@
 
 > This file persists context between Claude Code sessions.
 
+## Session 2026-07-20 — The Atelier (/atelier)
+
+- Opened the made-to-order desk: kernel.chat now takes commissions for
+  bespoke systems, hardware and software. Named THE ATELIER
+  (オーダーメイド) after deciding "commissions page" was too much
+  brochure and not enough experience.
+- Built `src/pages/AtelierPage.tsx` + `AtelierPage.css` as an
+  experience in the house interaction language: a commission dial
+  (ARIA radiogroup, four positions — Workstation 作業台 / Instrument
+  道具 / Floor 編集部 / Room 部屋), the five stages as a sequence
+  (Letter → Estimate → Deposit → Build → Handover), and a writable
+  commission slip (session-only, unrecorded) that composes the actual
+  mailto letter to hello@kernel.chat. Print stacks all states with
+  per-state running labels.
+- Standing terms on the page: fixed estimate before build (no posted
+  rate card — "the meter tells the truth"), half on commission /
+  balance on handover, client owns everything, BYOK, every handover
+  ships its audit trail. Each build may become an issue feature,
+  anonymized unless the client takes the byline.
+- Route `/atelier` wired in `router.tsx`; browser title in
+  `Layout.tsx`. Verified: `npx tsc --noEmit` clean, `npm run build`
+  clean, Playwright smoke on the preview server (dial, stages, slip,
+  composed mailto, zero page errors).
+- Environment note: `node_modules` needed `npm install
+  --ignore-scripts` in this container — the `canvas` devDependency's
+  prebuilt binary fetch fails and its source build wants cairo.
+  The site build does not need canvas.
+
 ## Session 2026-07-19 — `One of One` completed
 
 - Recovered the interrupted `one-of-one-2027` Palmier production from

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -30,6 +30,13 @@
   --ignore-scripts` in this container — the `canvas` devDependency's
   prebuilt binary fetch fails and its source build wants cairo.
   The site build does not need canvas.
+- Simulated a full visitor journey with Playwright (desktop keyboard
+  navigation of the dial + stages, mobile tap + reflow check) —
+  confirmed dial→subject wiring, zero page errors, no mobile
+  horizontal overflow. Found the page had no on-site discovery path.
+  Added "Made to Order" to `IssueColophon.tsx`'s link row (the shared
+  cover/issue footer) and "MADE TO ORDER →" to `MagazineFrame.tsx`'s
+  inner-page footer, so every surface routes to `/atelier`.
 
 ## Session 2026-07-19 — `One of One` completed
 

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -14,7 +14,8 @@
   道具 / Floor 編集部 / Room 部屋), the five stages as a sequence
   (Letter → Estimate → Deposit → Build → Handover), and a writable
   commission slip (session-only, unrecorded) that composes the actual
-  mailto letter to hello@kernel.chat. Print stacks all states with
+  mailto letter to kernel.chat@gmail.com (the confirmed intake
+  address). Print stacks all states with
   per-state running labels.
 - Standing terms on the page: fixed estimate before build (no posted
   rate card — "the meter tells the truth"), half on commission /

--- a/src/components/IssueColophon.tsx
+++ b/src/components/IssueColophon.tsx
@@ -38,6 +38,7 @@ export function IssueColophon({ issue }: IssueColophonProps) {
 
         <div className="pop-colophon-links">
           <a href="#/about">About</a>
+          <a href="#/atelier">Made to Order</a>
           <a href="#/issues">Back Issues</a>
           <a href="#/figma">Figma Spec</a>
           <a href="#/refusals">The Refusals</a>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -31,6 +31,7 @@ function titleForPath(pathname: string): string {
     case 'refusals': return 'Refusals · kernel.chat'
     case 'pressroom': return 'The Pressroom · kernel.chat'
     case 'about': return 'About · kernel.chat'
+    case 'atelier': return 'The Atelier · kernel.chat'
     case 'privacy': return 'Privacy · kernel.chat'
     case 'terms': return 'Terms · kernel.chat'
     default: return BASE_TITLE

--- a/src/components/MagazineFrame.tsx
+++ b/src/components/MagazineFrame.tsx
@@ -129,6 +129,9 @@ export function MagazineFrame({
               <a href="#/about" className="pop-folio pop-frame-back pop-frame-back--alt">
                 ABOUT →
               </a>
+              <a href="#/atelier" className="pop-folio pop-frame-back pop-frame-back--alt">
+                MADE TO ORDER →
+              </a>
               <a href="#/issues" className="pop-folio pop-frame-back pop-frame-back--alt">
                 ISSUES →
               </a>

--- a/src/pages/AtelierPage.css
+++ b/src/pages/AtelierPage.css
@@ -1,0 +1,320 @@
+/* ──────────────────────────────────────────────────────────────
+   /atelier — the made-to-order desk. Two calibrated instruments
+   (commission dial, five stages) and a writable slip, set in the
+   house register inside MagazineFrame. Calm by default: the page
+   at rest is complete; touch deepens, never gates. Motion is
+   weather — opacity/transform only, ≤4px, CSS-only.
+   ────────────────────────────────────────────────────────────── */
+.pop-atelier {
+  max-width: 680px;
+  margin: 0 auto;
+  padding-bottom: 24px;
+}
+
+.pop-atelier-lede {
+  font-family: var(--font-serif);
+  font-size: clamp(17px, 2.2vw, 20px);
+  line-height: 1.6;
+  color: var(--pop-ink);
+  margin: 8px 0 40px;
+}
+
+.pop-atelier-instrument { margin: 0 0 56px; }
+
+.pop-atelier-instrument h2 {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: clamp(24px, 3.6vw, 34px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--pop-ink);
+  margin: 0 0 8px;
+}
+
+.pop-atelier-no {
+  font-family: var(--font-mono);
+  font-size: 0.6em;
+  letter-spacing: 0.08em;
+  color: var(--pop-tomato);
+  margin-right: 10px;
+  vertical-align: 0.15em;
+}
+
+.pop-atelier-note {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  color: var(--pop-coffee);
+  margin: 0 0 18px;
+}
+
+/* ── Instrument I — the commission dial ──────────────────────── */
+.pop-atelier-dial {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin: 0 0 20px;
+}
+
+.pop-atelier-stop {
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-height: 44px;
+  padding: 10px 12px;
+  background: transparent;
+  border: 1px solid var(--pop-hairline-soft);
+  border-radius: 2px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.25s ease, transform 0.25s ease;
+}
+
+.pop-atelier-stop:hover { border-color: var(--pop-coffee); }
+
+.pop-atelier-stop.is-set {
+  border-color: var(--pop-tomato);
+  transform: translateY(-2px);
+}
+
+.pop-atelier-stop:focus-visible {
+  outline: 2px solid var(--pop-tomato);
+  outline-offset: 2px;
+}
+
+.pop-atelier-stop-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  color: var(--pop-ink);
+}
+
+.pop-atelier-stop.is-set .pop-atelier-stop-name { color: var(--pop-tomato); }
+
+.pop-atelier-stop-jp {
+  font-family: var(--font-jp, var(--font-serif));
+  font-size: var(--text-xs);
+  color: var(--pop-coffee);
+}
+
+.pop-atelier-spec {
+  border-left: 2px solid var(--pop-tomato);
+  padding: 4px 0 4px 18px;
+}
+
+.pop-atelier-spec-line {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: clamp(17px, 2.2vw, 20px);
+  line-height: 1.5;
+  color: var(--pop-ink);
+  margin: 0 0 12px;
+}
+
+.pop-atelier-spec ul { margin: 0 0 12px; padding-left: 20px; }
+
+.pop-atelier-spec li {
+  font-family: var(--font-serif);
+  font-size: clamp(16px, 2vw, 18px);
+  line-height: 1.55;
+  color: var(--pop-ink);
+  margin: 0 0 6px;
+}
+
+.pop-atelier-proof {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.03em;
+  line-height: 1.6;
+  color: var(--pop-coffee);
+  margin: 0;
+}
+
+/* ── Instrument II — the five stages ─────────────────────────── */
+.pop-atelier-stages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 18px;
+}
+
+.pop-atelier-stage {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--pop-hairline-soft);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.25s ease;
+}
+
+.pop-atelier-stage:hover { border-color: var(--pop-coffee); }
+.pop-atelier-stage.is-set { border-color: var(--pop-tomato); }
+
+.pop-atelier-stage:focus-visible {
+  outline: 2px solid var(--pop-tomato);
+  outline-offset: 2px;
+}
+
+.pop-atelier-stage-n {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--pop-tomato);
+}
+
+.pop-atelier-stage-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  color: var(--pop-ink);
+}
+
+.pop-atelier-stagebody p {
+  font-family: var(--font-serif);
+  font-size: clamp(16px, 2.1vw, 19px);
+  line-height: 1.6;
+  color: var(--pop-ink);
+  margin: 0;
+}
+
+.pop-atelier-stagejp {
+  font-family: var(--font-jp, var(--font-serif));
+  font-size: 0.85em;
+  color: var(--pop-coffee);
+  margin-right: 12px;
+}
+
+/* ── The slip ────────────────────────────────────────────────── */
+.pop-atelier-slip {
+  border: 1px solid var(--pop-coffee);
+  border-radius: 2px;
+  padding: 14px 16px 16px;
+  background: color-mix(in srgb, var(--pop-ivory) 55%, transparent);
+}
+
+.pop-atelier-slip-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-bottom: 10px;
+  margin-bottom: 12px;
+  border-bottom: 1px dashed var(--pop-hairline-soft);
+}
+
+.pop-atelier-slip-label {
+  display: block;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: clamp(15px, 2vw, 17px);
+  line-height: 1.5;
+  color: var(--pop-ink);
+  margin: 0 0 10px;
+}
+
+.pop-atelier-slip-field {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-serif);
+  font-size: clamp(15px, 2vw, 17px);
+  line-height: 1.55;
+  color: var(--pop-ink);
+  background: transparent;
+  border: 1px solid var(--pop-hairline-soft);
+  border-radius: 2px;
+  padding: 10px 12px;
+  resize: vertical;
+}
+
+.pop-atelier-slip-field:focus-visible {
+  outline: 2px solid var(--pop-tomato);
+  outline-offset: 2px;
+}
+
+.pop-atelier-slip-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.pop-atelier-post {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  color: var(--pop-tomato);
+  text-decoration: none;
+  border: 1px solid var(--pop-tomato);
+  border-radius: 2px;
+  padding: 10px 16px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.25s ease;
+}
+
+.pop-atelier-post:hover { transform: translateY(-2px); }
+
+.pop-atelier-post:focus-visible {
+  outline: 2px solid var(--pop-tomato);
+  outline-offset: 2px;
+}
+
+/* ── Standing terms ──────────────────────────────────────────── */
+.pop-atelier-terms { margin: 0; padding-left: 20px; }
+
+.pop-atelier-terms li {
+  font-family: var(--font-serif);
+  font-size: clamp(16px, 2vw, 19px);
+  line-height: 1.55;
+  color: var(--pop-ink);
+  margin: 0 0 8px;
+}
+
+/* ── Foot ────────────────────────────────────────────────────── */
+.pop-atelier-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 48px;
+  padding-top: 20px;
+  border-top: 1px solid var(--pop-hairline-soft);
+}
+
+/* ── Small measure ───────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .pop-atelier-dial { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ── Print: hide the controls, stack every state ─────────────── */
+@media print {
+  .pop-atelier-dial,
+  .pop-atelier-stages,
+  .pop-atelier-post { display: none; }
+
+  .pop-atelier-spec[hidden],
+  .pop-atelier-stagebody[hidden] { display: block; }
+
+  .pop-atelier-spec { margin-bottom: 18px; }
+  .pop-atelier-stagebody { margin-bottom: 12px; }
+
+  /* Each stacked state prints its own running label. */
+  .pop-atelier-spec::before,
+  .pop-atelier-stagebody::before {
+    content: attr(data-name);
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.06em;
+    margin-bottom: 8px;
+  }
+}

--- a/src/pages/AtelierPage.tsx
+++ b/src/pages/AtelierPage.tsx
@@ -128,7 +128,7 @@ const STAGES: Stage[] = [
   },
 ]
 
-const DESK_ADDRESS = 'hello@kernel.chat'
+const DESK_ADDRESS = 'kernel.chat@gmail.com'
 
 export function AtelierPage() {
   const [kindIndex, setKindIndex] = useState(0)

--- a/src/pages/AtelierPage.tsx
+++ b/src/pages/AtelierPage.tsx
@@ -1,0 +1,351 @@
+import { useState } from 'react'
+import type { KeyboardEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { MagazineFrame } from '../components/MagazineFrame'
+import './AtelierPage.css'
+
+/**
+ * /atelier — the made-to-order desk.
+ *
+ * The publication takes commissions: bespoke systems, hardware and
+ * software, built the way everything else in this repo was built —
+ * in public, evidence-cited, handed over with the audit trail.
+ *
+ * The page is an experience in the house interaction language, not
+ * a brochure. Two calibrated instruments and a writable slip:
+ *
+ *   1. The commission dial (ARIA radiogroup) — four positions on the
+ *      one variable the desk is about: what is being commissioned.
+ *   2. The five stages (ARIA tablist) — the ordered process from
+ *      letter to handover, each stage complete in itself.
+ *   3. The slip (native textarea) — session-only and unrecorded; it
+ *      composes the actual letter the visitor posts by mail.
+ *
+ * Everything stays on the page; print stacks all states.
+ */
+
+interface CommissionKind {
+  key: string
+  name: string
+  jp: string
+  line: string
+  spec: string[]
+  proof: string
+}
+
+const KINDS: CommissionKind[] = [
+  {
+    key: 'workstation',
+    name: 'THE WORKSTATION',
+    jp: '作業台',
+    line: 'A machine for working locally — spec’d, sourced, configured, delivered running.',
+    spec: [
+      'Local-first AI hardware: a rig sized to the models you actually run, not the ones in headlines.',
+      'Spec’d against your work, sourced, assembled or configured, and handed over already running.',
+      'Ollama / MLX / llama.cpp stack installed, tuned, and documented — the $0-per-token path.',
+      'Nothing phones home. The machine is yours the day it arrives.',
+    ],
+    proof: 'Proof on file: the local stack this publication runs on — Ollama, LLaDA, MLX — wired and shipped in the open.',
+  },
+  {
+    key: 'instrument',
+    name: 'THE INSTRUMENT',
+    jp: '道具',
+    line: 'A tool that does one job well — a CLI, an agent, an automation, a server.',
+    spec: [
+      'Custom software built to a fixed brief: command-line tools, specialist agents, MCP servers, pipelines.',
+      'BYOK by contract — the instrument never hardcodes a provider; your keys, your choice of model.',
+      'Ships with tests, documentation, and the reasoning behind every cut.',
+      'MIT-licensed to you unless the brief says otherwise.',
+    ],
+    proof: 'Proof on file: kbot — one hundred specialty skills on npm, curated from six hundred seventy with a public audit trail.',
+  },
+  {
+    key: 'floor',
+    name: 'THE FLOOR',
+    jp: '編集部',
+    line: 'A working system wired into your actual work — agents, daemons, the whole floor.',
+    spec: [
+      'An agent floor like the one that produces this magazine, built around your operation instead.',
+      'Background daemons for the around-the-clock work; specialist agents for the skilled work.',
+      'Wired into the places your work already lives — the channels, the repositories, the drives.',
+      'You keep the keys, the logs, and the off switch.',
+    ],
+    proof: 'Proof on file: this publication — drafted on an agent floor, signed off by hand, chain published.',
+  },
+  {
+    key: 'room',
+    name: 'THE ROOM',
+    jp: '部屋',
+    line: 'Hardware and software together — a studio, an install, a place that works.',
+    spec: [
+      'The integrated case: machine, software, and setting commissioned as one system.',
+      'Music production rigs — Ableton, Serum, Max for Live — wired for the way you actually write.',
+      'Production suites for film and media work, from intake to mastered delivery.',
+      'Documented so thoroughly you could rebuild the room without me.',
+    ],
+    proof: 'Proof on file: the thirty-two-tool film production suite and the music stack, both shipped and audited in this repository.',
+  },
+]
+
+interface Stage {
+  key: string
+  name: string
+  jp: string
+  body: string
+}
+
+const STAGES: Stage[] = [
+  {
+    key: 'letter',
+    name: 'THE LETTER',
+    jp: '手紙',
+    body: 'You write in. What you do, what keeps not working, what a good year would look like with the system in place. No forms, no calls booked by a robot — a letter, read by a person.',
+  },
+  {
+    key: 'estimate',
+    name: 'THE ESTIMATE',
+    jp: '見積',
+    body: 'I reply with a fixed estimate: what gets built, what it costs, how long it takes, and what is explicitly out of scope. The number does not move after you accept it. No rate card lives on this page because an honest price is quoted against real work, not posted next to a stock photograph.',
+  },
+  {
+    key: 'deposit',
+    name: 'THE DEPOSIT',
+    jp: '内金',
+    body: 'Half on commission. The commission enters the ledger, the bench is booked, and the build begins.',
+  },
+  {
+    key: 'build',
+    name: 'THE BUILD',
+    jp: '制作',
+    body: 'Built the way this repository is built: in the open with you, evidence-cited, decisions written down as they are made. You see the work while it is work, not just at the unveiling.',
+  },
+  {
+    key: 'handover',
+    name: 'THE HANDOVER',
+    jp: '引渡',
+    body: 'The balance is due when the system is yours: running, documented, and handed over with its audit trail. Your keys, your accounts, your machine. No lock-in, no dependency on me, no subscription wearing a bow. If the build is worth writing about, it may appear in a future issue — anonymized unless you would rather take the byline.',
+  },
+]
+
+const DESK_ADDRESS = 'hello@kernel.chat'
+
+export function AtelierPage() {
+  const [kindIndex, setKindIndex] = useState(0)
+  const [stageIndex, setStageIndex] = useState(0)
+  const [slip, setSlip] = useState('')
+
+  const kind = KINDS[kindIndex]
+
+  const onDialKey = (event: KeyboardEvent<HTMLDivElement>) => {
+    const delta =
+      event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 :
+      event.key === 'ArrowLeft' || event.key === 'ArrowUp' ? -1 : 0
+    if (delta === 0) return
+    event.preventDefault()
+    const next = (kindIndex + delta + KINDS.length) % KINDS.length
+    setKindIndex(next)
+    const group = event.currentTarget
+    const radios = group.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+    radios[next]?.focus()
+  }
+
+  const onStagesKey = (event: KeyboardEvent<HTMLDivElement>) => {
+    const delta =
+      event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 :
+      event.key === 'ArrowLeft' || event.key === 'ArrowUp' ? -1 : 0
+    if (delta === 0) return
+    event.preventDefault()
+    const next = (stageIndex + delta + STAGES.length) % STAGES.length
+    setStageIndex(next)
+    const list = event.currentTarget
+    const tabs = list.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    tabs[next]?.focus()
+  }
+
+  const letterSubject = `ATELIER — ${kind.name}`
+  const letterBody = slip.trim()
+  const mailHref =
+    `mailto:${DESK_ADDRESS}` +
+    `?subject=${encodeURIComponent(letterSubject)}` +
+    (letterBody ? `&body=${encodeURIComponent(letterBody)}` : '')
+
+  return (
+    <MagazineFrame
+      kicker="ATELIER"
+      title="Made to order."
+      titleJp="オーダーメイド"
+      deck="The publication takes commissions. Bespoke systems — hardware and software — built the way everything here is built: in the open, evidence-cited, handed over whole."
+      stock="cream"
+    >
+      <div className="pop-section-inner">
+        <div className="pop-atelier">
+
+          <p className="pop-atelier-lede">
+            Every system in this repository was built for our own work first —
+            the agent floor that drafts these pages, the local models that cost
+            nothing per token, the production suites, the music rigs. The
+            atelier builds one for you. The portfolio is not a highlight reel;
+            it is the repository itself, audit trails included.
+          </p>
+
+          {/* ── Instrument I — the commission dial ─────────── */}
+          <section className="pop-atelier-instrument" aria-labelledby="atelier-dial-head">
+            <h2 id="atelier-dial-head">
+              <span className="pop-atelier-no">I.</span> What is being commissioned
+            </h2>
+            <p className="pop-atelier-note">
+              Four positions. Turn the dial; the spec sheet follows.
+            </p>
+
+            <div
+              className="pop-atelier-dial"
+              role="radiogroup"
+              aria-label="Kind of commission"
+              onKeyDown={onDialKey}
+            >
+              {KINDS.map((k, i) => (
+                <button
+                  key={k.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={i === kindIndex}
+                  tabIndex={i === kindIndex ? 0 : -1}
+                  className={`pop-atelier-stop${i === kindIndex ? ' is-set' : ''}`}
+                  onClick={() => setKindIndex(i)}
+                >
+                  <span className="pop-atelier-stop-name">{k.name}</span>
+                  <span className="pop-atelier-stop-jp" lang="ja">{k.jp}</span>
+                </button>
+              ))}
+            </div>
+
+            {KINDS.map((k, i) => (
+              <article
+                key={k.key}
+                className="pop-atelier-spec"
+                data-name={k.name}
+                hidden={i !== kindIndex}
+                aria-label={`${k.name} — spec sheet`}
+              >
+                <p className="pop-atelier-spec-line">{k.line}</p>
+                <ul>
+                  {k.spec.map(item => <li key={item}>{item}</li>)}
+                </ul>
+                <p className="pop-atelier-proof">{k.proof}</p>
+              </article>
+            ))}
+          </section>
+
+          {/* ── Instrument II — the five stages ────────────── */}
+          <section className="pop-atelier-instrument" aria-labelledby="atelier-stages-head">
+            <h2 id="atelier-stages-head">
+              <span className="pop-atelier-no">II.</span> How a commission runs
+            </h2>
+            <p className="pop-atelier-note">
+              Five stages, in order. Each one is complete before the next begins.
+            </p>
+
+            <div
+              className="pop-atelier-stages"
+              role="tablist"
+              aria-label="Stages of a commission"
+              onKeyDown={onStagesKey}
+            >
+              {STAGES.map((s, i) => (
+                <button
+                  key={s.key}
+                  type="button"
+                  role="tab"
+                  id={`atelier-stage-tab-${s.key}`}
+                  aria-selected={i === stageIndex}
+                  aria-controls={`atelier-stage-${s.key}`}
+                  tabIndex={i === stageIndex ? 0 : -1}
+                  className={`pop-atelier-stage${i === stageIndex ? ' is-set' : ''}`}
+                  onClick={() => setStageIndex(i)}
+                >
+                  <span className="pop-atelier-stage-n">{i + 1}</span>
+                  <span className="pop-atelier-stage-name">{s.name}</span>
+                </button>
+              ))}
+            </div>
+
+            {STAGES.map((s, i) => (
+              <div
+                key={s.key}
+                id={`atelier-stage-${s.key}`}
+                role="tabpanel"
+                aria-labelledby={`atelier-stage-tab-${s.key}`}
+                className="pop-atelier-stagebody"
+                data-name={`${i + 1}. ${s.name}`}
+                hidden={i !== stageIndex}
+              >
+                <p>
+                  <span className="pop-atelier-stagejp" lang="ja">{s.jp}</span>
+                  {s.body}
+                </p>
+              </div>
+            ))}
+          </section>
+
+          {/* ── The slip ───────────────────────────────────── */}
+          <section className="pop-atelier-instrument" aria-labelledby="atelier-slip-head">
+            <h2 id="atelier-slip-head">
+              <span className="pop-atelier-no">III.</span> The slip
+            </h2>
+            <p className="pop-atelier-note">
+              Write the letter here if you like — the slip is session-only and
+              unrecorded; nothing leaves this page until you post it. Reload
+              erases it.
+            </p>
+
+            <div className="pop-atelier-slip">
+              <div className="pop-atelier-slip-head">
+                <span className="pop-folio">COMMISSION SLIP</span>
+                <span className="pop-folio">{kind.name} · <span lang="ja">{kind.jp}</span></span>
+              </div>
+              <label className="pop-atelier-slip-label" htmlFor="atelier-slip">
+                What you do, what keeps not working, and what a good year would
+                look like with the system in place:
+              </label>
+              <textarea
+                id="atelier-slip"
+                className="pop-atelier-slip-field"
+                value={slip}
+                onChange={e => setSlip(e.target.value)}
+                rows={7}
+                spellCheck={false}
+              />
+              <div className="pop-atelier-slip-foot">
+                <span className="pop-folio">TO: {DESK_ADDRESS}</span>
+                <a className="pop-atelier-post" href={mailHref}>
+                  POST THE LETTER →
+                </a>
+              </div>
+            </div>
+          </section>
+
+          {/* ── Standing terms ─────────────────────────────── */}
+          <section className="pop-atelier-instrument" aria-labelledby="atelier-terms-head">
+            <h2 id="atelier-terms-head">
+              <span className="pop-atelier-no">IV.</span> Standing terms
+            </h2>
+            <ul className="pop-atelier-terms">
+              <li>The estimate is fixed before the build begins, and does not move after you accept it.</li>
+              <li>Half on commission, the balance on handover.</li>
+              <li>You own the result — the machine, the code, the keys, the documentation.</li>
+              <li>BYOK everywhere. Nothing in the build ties you to a provider, or to me.</li>
+              <li>Every handover ships with its audit trail, the same as every release in this repository.</li>
+            </ul>
+          </section>
+
+          <div className="pop-atelier-foot">
+            <Link to="/" className="pop-folio">← back to the cover</Link>
+            <Link to="/about" className="pop-folio">why this exists →</Link>
+          </div>
+
+        </div>
+      </div>
+    </MagazineFrame>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -21,6 +21,7 @@ const PrototypePage = lazyRetry(() => import('./pages/PrototypePage').then(m => 
 const CreativeCanvasPage = lazyRetry(() => import('./pages/CreativeCanvasPage').then(m => ({ default: m.CreativeCanvasPage })))
 const MotionSheetPage = lazyRetry(() => import('./pages/MotionSheetPage').then(m => ({ default: m.MotionSheetPage })))
 const PalmierSuitePage = lazyRetry(() => import('./pages/PalmierSuitePage').then(m => ({ default: m.PalmierSuitePage })))
+const AtelierPage = lazyRetry(() => import('./pages/AtelierPage').then(m => ({ default: m.AtelierPage })))
 
 function withErrorBoundary(element: React.ReactNode) {
   return <ErrorBoundary>{element}</ErrorBoundary>
@@ -105,6 +106,11 @@ export const router = createHashRouter([
       { path: 'pressroom', element: withErrorBoundary(
         <Suspense fallback={<div className="ka-page-loading">Loading the pressroom...</div>}>
           <PressroomPage />
+        </Suspense>
+      ) },
+      { path: 'atelier', element: withErrorBoundary(
+        <Suspense fallback={<div className="ka-page-loading">Loading the atelier...</div>}>
+          <AtelierPage />
         </Suspense>
       ) },
       { path: 'about', element: withErrorBoundary(


### PR DESCRIPTION
## What

Opens a commissions surface for the publication: **THE ATELIER** at `#/atelier` ("Made to order · オーダーメイド"). kernel.chat now takes commissions for bespoke systems — hardware and software — built the way the repository is built: in the open, evidence-cited, handed over with the audit trail.

New files: `src/pages/AtelierPage.tsx` + `AtelierPage.css`; route wired in `src/router.tsx`; browser title in `src/components/Layout.tsx`; session entry in `SCRATCHPAD.md`.

## Why

The systems in this repo (agent floor, local-AI stack, production suites, music rigs) were all built for our own work first — the atelier offers to build one for a client, with the repository itself as the portfolio. Named "Atelier" rather than "Commissions" and built as an experience rather than a brochure, per direction.

## How

An experience in the house interaction language, not static prose:

- **The commission dial** (ARIA radiogroup, roving tabindex) — four positions: THE WORKSTATION 作業台 / THE INSTRUMENT 道具 / THE FLOOR 編集部 / THE ROOM 部屋, each with a spec sheet and a proof-on-file line citing real shipped work.
- **The five stages** (ARIA tablist) — Letter → Estimate → Deposit → Build → Handover.
- **The slip** (native textarea, session-only and unrecorded) — composes the actual `mailto:kernel.chat@gmail.com` letter, subject stamped with the dialed commission kind.
- **Standing terms** — fixed estimate before build, half on commission / balance on handover, client owns everything, BYOK, audit trail ships with every handover.

Trade-offs held to the house rules: no posted rate card (the meter tells the truth — an honest price is quoted against real work); CSS-only motion at weather amplitude (≤4px translate); every state stays in the DOM; print hides the controls and stacks all states with per-state running labels; magazine vocabulary throughout, no emojis.

## Testing

- [x] `npm run build` passes
- [ ] `npm run test` passes (not run — this PR touches only the magazine surface; `canvas` devDependency cannot compile in this container)
- [x] `npx tsc --noEmit` passes
- [ ] Tested manually with `kbot` in dev mode (n/a — no kbot changes)

Also verified with a Playwright smoke test against `vite preview`: page title, dial selection, stage selection, slip input, and the composed mailto href, with zero page errors.

## Screenshots

Full-page render on the preview server: masthead and bilingual head render in the house grammar; dial at THE FLOOR shows its spec sheet; stage 5 (THE HANDOVER) panel open; slip composed with `TO: kernel.chat@gmail.com / POST THE LETTER →`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwdhQkHLaxbTwsdAAjo4YK