### PR TITLE
Atelier: split the deposit so hardware cost is never fronted

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -2,6 +2,21 @@
 
 > This file persists context between Claude Code sessions.
 
+## Session 2026-07-20 (cont.) — Atelier deposit terms fixed
+
+- After THE ATELIER shipped (PR #59, merged), the user flagged the real
+  problem: "half on commission" doesn't protect against fronting
+  hardware cost on THE WORKSTATION / THE ROOM commissions if parts
+  exceed half the estimate.
+- Split the deposit into two lines everywhere it's described (THE
+  DEPOSIT stage body, the Standing terms list, and the WORKSTATION/
+  ROOM spec sheets): hardware and materials are billed at cost and
+  due before anything is ordered — never fronted; labor stays half
+  on commission / half on handover.
+- Verified with Playwright against the rebuilt preview server: deposit
+  stage body, standing-terms list items, and the workstation spec
+  sheet all render the new copy with zero page errors.
+
 ## Session 2026-07-20 — The Atelier (/atelier)
 
 - Opened the made-to-order desk: kernel.chat now takes commissions for

--- a/src/pages/AtelierPage.tsx
+++ b/src/pages/AtelierPage.tsx
@@ -44,6 +44,7 @@ const KINDS: CommissionKind[] = [
       'Spec’d against your work, sourced, assembled or configured, and handed over already running.',
       'Ollama / MLX / llama.cpp stack installed, tuned, and documented — the $0-per-token path.',
       'Nothing phones home. The machine is yours the day it arrives.',
+      'Parts are invoiced at cost before anything is ordered — the build never carries the hardware bill for you.',
     ],
     proof: 'Proof on file: the local stack this publication runs on — Ollama, LLaDA, MLX — wired and shipped in the open.',
   },
@@ -83,6 +84,7 @@ const KINDS: CommissionKind[] = [
       'Music production rigs — Ableton, Serum, Max for Live — wired for the way you actually write.',
       'Production suites for film and media work, from intake to mastered delivery.',
       'Documented so thoroughly you could rebuild the room without me.',
+      'Any hardware in the room is invoiced at cost before it is ordered, the same as a standalone workstation.',
     ],
     proof: 'Proof on file: the thirty-two-tool film production suite and the music stack, both shipped and audited in this repository.',
   },
@@ -112,7 +114,7 @@ const STAGES: Stage[] = [
     key: 'deposit',
     name: 'THE DEPOSIT',
     jp: '内金',
-    body: 'Half on commission. The commission enters the ledger, the bench is booked, and the build begins.',
+    body: 'Two lines on the estimate, not one. Hardware and materials are billed at cost and due before anything is ordered — the build never fronts the parts bill on your behalf. Labor is billed half on commission, half on handover. The commission enters the ledger, the bench is booked, and the build begins once the deposit clears.',
   },
   {
     key: 'build',
@@ -332,7 +334,8 @@ export function AtelierPage() {
             </h2>
             <ul className="pop-atelier-terms">
               <li>The estimate is fixed before the build begins, and does not move after you accept it.</li>
-              <li>Half on commission, the balance on handover.</li>
+              <li>Hardware and materials are billed at cost, due before anything is ordered — the build never fronts the parts bill on your behalf.</li>
+              <li>Labor is billed half on commission, half on handover.</li>
               <li>You own the result — the machine, the code, the keys, the documentation.</li>
               <li>BYOK everywhere. Nothing in the build ties you to a provider, or to me.</li>
               <li>Every handover ships with its audit trail, the same as every release in this repository.</li>


### PR DESCRIPTION
## What

Fixes the deposit structure on THE ATELIER (`#/atelier`, shipped in #59). "Half on commission, the balance on handover" doesn't protect against fronting hardware cost when parts exceed half the estimate — a real problem for THE WORKSTATION and THE ROOM, the two commission kinds that involve physical hardware.

## Why

The user can't afford to float parts money. The fix: split every place the deposit is described into two lines — hardware/materials billed at cost and due before anything is ordered (never fronted), labor billed half on commission / half on handover.

## How

- `THE DEPOSIT` stage body rewritten with the two-line split.
- `Standing terms` list: replaced the single "half on commission" bullet with two bullets (materials-at-cost-before-ordering, labor-half-half).
- Added a matching spec-sheet bullet to `THE WORKSTATION` and `THE ROOM` (the two hardware-involving commission kinds) noting parts are invoiced at cost before ordering.

No structural or route changes — copy only, within the same page shipped in #59.

## Testing

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] `npm run test` (not run — `canvas` devDependency can't compile in this container, same as #59)

Verified with a Playwright pass against the rebuilt `vite preview` server: THE DEPOSIT stage body, all six Standing terms list items, and THE WORKSTATION spec sheet all render the new copy, zero page errors.

## Screenshots

n/a — copy-only change; verified via Playwright text assertions rather than a fresh screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwdhQkHLaxbTwsdAAjo4YK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwdhQkHLaxbTwsdAAjo4YK)_