### PR TITLE
ISSUE 428 — NOTHING NEW WAS ADDED

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -2854,3 +2854,31 @@ Removed the Canvas page and Creative Studio from the website, replacing it with 
   the relay session.
 - test:palmier script pointed at vitest (node --test broke after the
   runner port).
+
+## Session 2026-08-01 — ISSUE 428 pressed (branch: claude/youtube-monetization-rules-pv8pos)
+
+- ISSUE 428 "NOTHING NEW WAS ADDED" — YouTube's 15 July 2025
+  "inauthentic content" rename, read under two lenses. `compare`,
+  second instance (406 was the first); no pattern extracted per
+  interaction-language rule 7. cream stock, classic layout, brick
+  accent, coverSeal NO NEW POLICIES · III·27.
+- Six facts, all externally sourced and dated, verified against the
+  platform's own help pages plus Social Media Today / PPC Land /
+  Search Engine Journal / Tubefilter before the issue was set. This is
+  why CompareSpread gained an optional `references` block (406
+  unaffected); CompareFeature + CSS render it under `pop-compare-refs`.
+- Unlike 406 this piece GIVES a verdict: THE LETTER and THE QUEUE
+  answer different questions (what you are owed vs what you meet), so
+  declining would have been a false symmetry rather than honesty.
+- Artifact edition `artifacts/428-nothing-new-was-added.html` — THE
+  REVIEW QUEUE, six-stratum descent (upload → classifier → three
+  buckets → second look → icon → the rule). Depth axis = the review
+  stack; carried context = the upload's character (three authored
+  composites) re-inking every stratum; floor resolves per carry.
+  Seed 428-0715 printed. Timer-robust clock (rAF-vs-setTimeout race),
+  reduced-motion collapse, print stacks all strata.
+- Gates: check-editorial clean (69 issues), check-adherence clean
+  (0 raw hex), `npm run build` green, 811/811 vitest.
+- NOT deployed. This is a feature branch; only a push to main
+  publishes. Artifact not published to the claude.ai surface either —
+  Isaac's call.

--- a/artifacts/428-nothing-new-was-added.html
+++ b/artifacts/428-nothing-new-was-added.html
@@ -1,0 +1,435 @@
+<style>
+  /* ISSUE 428 — NOTHING NEW WAS ADDED · 何ひとつ新しくはない
+     Artifact edition: THE REVIEW QUEUE — a six-stratum descent of one
+     upload from the file to the rule that judges it. Tokens mirrored
+     from src/index.css. Accent: brick (archival seed) on cream stock.
+     Depth axis = the review stack. Carried context = the upload's
+     character, chosen at the surface, re-inking every stratum below.
+     Nothing here calls any service; every stratum is drawn in-house
+     from the cited policy text. Seed prints on the masthead. */
+  :root{
+    --ink:#1F1E1D; --ivory:#FAF9F6; --cream:#F3E9D2; --ledger:#F2EFE2;
+    --brick:#9E3A2B; --brick-lift:#C25F4A; --brick-dim:#7A3A31;
+    --coffee:#6B5B4A;
+    --hair:rgba(31,30,29,.18); --hair-strong:rgba(31,30,29,.42);
+    --paper:var(--cream); --type:var(--ink); --accent:var(--brick);
+    --serif:"EB Garamond","Iowan Old Style",Palatino,Georgia,serif;
+    --mono:"Courier Prime","Courier New",monospace;
+    --jp:"Noto Serif JP","Hiragino Mincho ProN","Yu Mincho",serif;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{--paper:var(--ink); --type:var(--ivory); --accent:var(--brick-lift);
+      --coffee:#A99684; --hair:rgba(250,249,246,.16); --hair-strong:rgba(250,249,246,.4)}
+  }
+  .rq-root{background:var(--paper);color:var(--type);font-family:var(--serif);
+    margin:0;min-height:100svh;position:relative;overflow-x:hidden}
+  .rq-root *{box-sizing:border-box}
+  .rq-frame{position:relative;z-index:1;max-width:1040px;margin:0 auto;padding:0 clamp(16px,4vw,44px)}
+
+  .rq-mast{display:flex;justify-content:space-between;align-items:baseline;gap:12px;flex-wrap:wrap;
+    padding:20px 0 14px;border-bottom:1px solid var(--hair-strong);
+    font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;text-transform:uppercase}
+  .rq-mast b{color:var(--accent);font-weight:400}
+  .rq-seed{opacity:.65}
+  .rq-glyph{color:var(--accent)}
+
+  .rq-hero{padding:clamp(28px,6vh,60px) 0 4px}
+  .rq-kicker{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;color:var(--accent);margin:0}
+  .rq-kicker::before{content:"[ "}.rq-kicker::after{content:" ]"}
+  .rq-hero h1{font-size:clamp(2.3rem,7.2vw,5.2rem);line-height:.98;letter-spacing:-.025em;
+    margin:.3em 0 .1em;font-weight:700;text-wrap:balance}
+  .rq-hero h1 em{font-style:italic;color:var(--accent)}
+  .rq-jp{font-family:var(--jp);font-size:clamp(.9rem,2vw,1.12rem);color:var(--accent);opacity:.88;margin:0}
+  .rq-deck{max-width:60ch;font-size:1.05rem;line-height:1.62;opacity:.92;margin:1.15em 0 0}
+
+  /* ── the carry: what is being lowered ─────────────────── */
+  .rq-carry{margin:34px 0 6px;border-top:1px solid var(--hair-strong);padding-top:18px}
+  .rq-carry h2,.rq-ledger h2{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--accent);font-weight:400;margin:0 0 10px}
+  .rq-chips{display:flex;flex-wrap:wrap;gap:10px;margin:0 0 12px;padding:0;list-style:none}
+  .rq-chip{font-family:var(--mono);font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+    background:none;border:1px solid var(--hair-strong);color:var(--type);
+    padding:13px 18px;min-height:44px;cursor:pointer;text-align:left;
+    transition:background .16s,color .16s,border-color .16s}
+  .rq-chip:hover{border-color:var(--accent)}
+  .rq-chip:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+  .rq-chip[aria-pressed="true"]{background:var(--accent);border-color:var(--accent);color:var(--paper)}
+  .rq-chip small{display:block;font-size:.58rem;letter-spacing:.08em;opacity:.72;margin-top:3px;text-transform:none}
+  .rq-carrynote{font-family:var(--mono);font-size:.62rem;letter-spacing:.08em;opacity:.7;margin:0;max-width:64ch}
+
+  /* ── the gauge + the bore ──────────────────────────────── */
+  .rq-rig{display:grid;grid-template-columns:120px 1fr;gap:0 clamp(14px,3vw,32px);margin:26px 0 0}
+  .rq-gauge{position:relative;border-right:1px solid var(--hair-strong);padding:6px 14px 6px 0}
+  .rq-gstop{display:flex;justify-content:flex-end;align-items:baseline;gap:8px;height:var(--stop-h);
+    font-family:var(--mono);font-size:.66rem;letter-spacing:.1em;opacity:.5;transition:opacity .2s,color .2s}
+  .rq-gstop .jp{font-family:var(--jp);font-size:.62rem}
+  .rq-gstop.at{opacity:1;color:var(--accent)}
+  .rq-probe-mark{position:absolute;right:-5px;width:9px;height:9px;background:var(--accent);
+    transform:translateY(-50%) rotate(45deg);transition:top .5s cubic-bezier(.3,.9,.3,1)}
+
+  .rq-strata{margin:0;padding:0;list-style:none}
+  .rq-stratum{min-height:var(--stop-h);padding:6px 0 22px;border-bottom:1px dashed var(--hair);
+    opacity:.42;transition:opacity .35s ease}
+  .rq-stratum.lit{opacity:1}
+  .rq-stratum:last-child{border-bottom:0}
+  .rq-shead{font-family:var(--mono);font-size:.66rem;letter-spacing:.13em;text-transform:uppercase;margin:0}
+  .rq-stratum.lit .rq-shead{color:var(--accent)}
+  .rq-shead .jp{font-family:var(--jp);letter-spacing:.04em;text-transform:none;opacity:.8}
+  .rq-sbody{font-size:1.02rem;line-height:1.6;margin:.5em 0 .6em;max-width:60ch}
+  .rq-sread{font-size:.98rem;line-height:1.58;margin:0;max-width:60ch;
+    border-left:2px solid var(--accent);padding-left:14px}
+  .rq-sread .tag{display:block;font-family:var(--mono);font-size:.58rem;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--accent);margin-bottom:4px}
+  .rq-scap{font-family:var(--mono);font-size:.58rem;letter-spacing:.1em;opacity:.6;margin:.7em 0 0}
+
+  .rq-winch{display:flex;flex-wrap:wrap;align-items:center;gap:14px;margin:26px 0 0}
+  .rq-winch button{font-family:var(--mono);font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;
+    background:none;border:1px solid var(--accent);color:var(--accent);
+    padding:15px 24px;min-height:44px;cursor:pointer;
+    transition:transform .14s cubic-bezier(.2,1.6,.4,1),background .14s,color .14s}
+  .rq-winch button:hover{background:var(--accent);color:var(--paper)}
+  .rq-winch button:active{transform:scale(.96)}
+  .rq-winch button:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+  .rq-winch small{font-family:var(--mono);font-size:.62rem;letter-spacing:.08em;opacity:.65;max-width:46ch}
+
+  /* ── the floor ─────────────────────────────────────────── */
+  .rq-floor{background:var(--ledger);color:var(--ink);margin:48px calc(50% - 50vw) 0;padding:42px 0 34px}
+  @media (prefers-color-scheme:dark){.rq-floor{background:rgba(250,249,246,.06);color:var(--ivory)}}
+  .rq-floor h2{font-family:var(--mono);font-size:.66rem;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--brick);font-weight:400;margin:0 0 14px}
+  @media (prefers-color-scheme:dark){.rq-floor h2{color:var(--brick-lift)}}
+  .rq-floor .rule{font-size:clamp(1.2rem,3.2vw,1.7rem);line-height:1.42;font-style:italic;
+    max-width:46ch;margin:0 0 18px}
+  .rq-floor .resolve{font-size:1.02rem;line-height:1.62;max-width:58ch;margin:0}
+  .rq-floor .stamp{display:inline-block;margin-top:20px;border:1px solid var(--brick);color:var(--brick);
+    font-family:var(--mono);font-size:.6rem;letter-spacing:.16em;text-transform:uppercase;
+    padding:8px 14px;transform:rotate(-1.4deg)}
+  @media (prefers-color-scheme:dark){.rq-floor .stamp{border-color:var(--brick-lift);color:var(--brick-lift)}}
+
+  .rq-ledger{border-top:1px solid var(--hair-strong);margin-top:44px;padding-top:16px}
+  .rq-ledger ul{list-style:none;margin:0;padding:0;font-family:var(--mono);font-size:.7rem;
+    line-height:2;font-variant-numeric:tabular-nums}
+  .rq-ledger li{border-bottom:1px dashed var(--hair);display:flex;justify-content:space-between;gap:12px}
+  .rq-ledger li b{color:var(--accent);font-weight:400}
+
+  .rq-colophon{padding:34px 0 48px;font-family:var(--mono);font-size:.63rem;
+    letter-spacing:.07em;line-height:1.95;opacity:.8;max-width:74ch}
+  .rq-colophon b{color:var(--accent);font-weight:400}
+
+  @media (max-width:720px){
+    .rq-rig{grid-template-columns:64px 1fr;gap:0 14px}
+    .rq-gstop{font-size:.6rem;gap:5px}
+    .rq-gstop .jp{display:none}
+    .rq-chip{width:100%}
+  }
+  @media (prefers-reduced-motion:reduce){
+    *{animation:none!important;transition:none!important}
+    .rq-stratum{opacity:1}
+  }
+  @media print{
+    .rq-root{background:#fff;color:#1F1E1D}
+    .rq-winch,.rq-chips{display:none}
+    .rq-stratum{opacity:1!important;break-inside:avoid}
+    .rq-floor{background:none;margin:20px 0 0;color:#1F1E1D}
+    .rq-shead,.rq-kicker,.rq-hero h1 em,.rq-jp,.rq-ledger li b{color:#9E3A2B}
+  }
+</style>
+
+<div class="rq-root" id="rq-root">
+<div class="rq-frame">
+
+  <header class="rq-mast">
+    <span>KERNEL.CHAT · ISSUE <b>428</b> · MAR 2027</span>
+    <span class="rq-glyph">★</span>
+    <span class="rq-seed">SEED 428-0715 · PRINTED</span>
+  </header>
+
+  <section class="rq-hero">
+    <p class="rq-kicker">THE BORE · 掘削 · THE POLICY DESK</p>
+    <h1>Nothing new <em>was added.</em></h1>
+    <p class="rq-jp">何ひとつ新しくはない — 規則は動かず、審査の列だけが動いた</p>
+    <p class="rq-deck">The spread argues the text. This page lowers a probe through the
+    machinery the text runs on: six strata from the file you uploaded to the sentence
+    that judges it. Pick what you are sending down first — the carry re-inks every
+    stratum beneath it. Every stratum is legible from the surface; the probe raises
+    emphasis, it never conjures a layer that was not already there.</p>
+  </section>
+
+  <section class="rq-carry">
+    <h2>The carry · 積荷 — what is being lowered</h2>
+    <ul class="rq-chips">
+      <li><button class="rq-chip" type="button" data-carry="hand" aria-pressed="true">Original commentary<small>one voice, own cuts, own argument</small></button></li>
+      <li><button class="rq-chip" type="button" data-carry="mill" aria-pressed="false">Templated at scale<small>same narration, swapped slides, forty a day</small></button></li>
+      <li><button class="rq-chip" type="button" data-carry="oracle" aria-pressed="false">Synthetic presenter, health<small>a persona advising on blood pressure</small></button></li>
+    </ul>
+    <p class="rq-carrynote">The three carries are authored composites, written from the
+    policy text — not case files, not anyone's channel.</p>
+  </section>
+
+  <div class="rq-rig">
+    <div class="rq-gauge" id="rq-gauge" aria-hidden="true">
+      <span class="rq-probe-mark" id="rq-mark"></span>
+    </div>
+    <ol class="rq-strata" id="rq-strata"></ol>
+  </div>
+
+  <div class="rq-winch">
+    <button id="rq-lower" type="button">★ Lower the probe</button>
+    <small>One control, honestly geared: each press descends exactly one stratum.
+    At the floor it raises you back to the surface.</small>
+  </div>
+
+  <section class="rq-ledger">
+    <h2>Session ledger · 台帳 — this window only; unrecorded; reload erases it</h2>
+    <ul>
+      <li><span>DEPTH REACHED</span><b id="rq-depth">0 of 5</b></li>
+      <li><span>DESCENTS</span><b id="rq-drops">0</b></li>
+      <li><span>CARRIES CHANGED</span><b id="rq-carries">0</b></li>
+      <li><span>TIME IN THE BORE</span><b id="rq-clock">00:00</b></li>
+    </ul>
+  </section>
+</div>
+
+  <section class="rq-floor">
+    <div class="rq-frame">
+      <h2>The floor · 底 — stratum −5, the rule itself</h2>
+      <p class="rule">Content must be original and authentic. On 15 July 2025 that
+      sentence was renamed, not rewritten.</p>
+      <p class="resolve" id="rq-resolve"></p>
+      <span class="stamp">No new policies were added · III·27</span>
+    </div>
+  </section>
+
+<div class="rq-frame">
+  <footer class="rq-colophon">
+    <p>NOTHING NEW WAS ADDED · 何ひとつ新しくはない · KERNEL PRESS <span class="rq-glyph">★</span><br>
+    Every stratum on this page is drawn in-house from published policy text — nothing is
+    generated, no request leaves this page, and no channel or upload is described. The three
+    carries are authored composites. The bore is deterministic from seed <b>428-0715</b>,
+    printed at the masthead: at rest it always reads the same. The session ledger counts only
+    your own descents, carry changes, and the clock since this page loaded; it is held in
+    memory, sent nowhere, and erased on reload. Under reduced motion the probe stops moving
+    and every stratum stands at full ink. Print stacks all six strata, at every carry, with
+    the controls removed. Sources: the platform's monetization policy pages and the
+    additional-reviews notice of 10 March 2025, cited in full in the issue's policy file.</p>
+  </footer>
+</div>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  var reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* deterministic — the seed prints on the masthead; nothing here is random.
+     mulberry32 is carried for the house contract (a printed seed must be able
+     to redraw any state the reader saw) and used only for the settle cadence. */
+  function mulberry32(a){return function(){a|=0;a=a+0x6D2B79F5|0;var t=Math.imul(a^a>>>15,1|a);t=t+Math.imul(t^t>>>7,61|t)^t;return((t^t>>>14)>>>0)/4294967296}}
+  var rng = mulberry32(4280715);
+
+  var CARRIES = {
+    hand:   'ORIGINAL COMMENTARY',
+    mill:   'TEMPLATED AT SCALE',
+    oracle: 'SYNTHETIC PRESENTER, HEALTH'
+  };
+
+  var STRATA = [
+    {
+      gauge:'0m', jp:'表層',
+      label:'STRATUM 0 · THE UPLOAD', labelJp:'投稿',
+      body:'The file lands. Nothing has judged it yet, and for most of the platform’s history this is where the story ended.',
+      read:{
+        hand:'Forty-one minutes, one voice, three cuts that only work if you were in the room when they happened.',
+        mill:'Video thirty-one of the day. Same narration bed, new slides, new thumbnail, same forty seconds of outro.',
+        oracle:'A face that does not exist, in a set that does not exist, explaining what to do about your blood pressure.'
+      },
+      cap:'FIG. 1 — the file, before anything has read it.'
+    },
+    {
+      gauge:'−1', jp:'自動判定',
+      label:'STRATUM −1 · THE CLASSIFIER', labelJp:'広告適合性の一次審査',
+      body:'The ad-suitability pass. It runs in minutes on nearly everything, and it is asking about advertiser safety — not about authorship.',
+      read:{
+        hand:'Passes in under a minute. Most content does. This is the boring outcome the whole policy is built around.',
+        mill:'Passes too. Nothing in one upload is repetitive — repetition is a property of a channel, and this pass is looking at a file.',
+        oracle:'Passes. Ad-suitability is not authenticity; at this depth the machine is answering a different question entirely.'
+      },
+      cap:'FIG. 2 — the first pass judges the frame, not the pattern.'
+    },
+    {
+      gauge:'−2', jp:'三分類',
+      label:'STRATUM −2 · THE THREE BUCKETS', labelJp:'収益化対象外の三分類',
+      body:'Generic or mass-produced. Off-putting or distressing. A synthetic persona presenting as an authority on health, finance, law, or politics. This is the stratum that was renamed on 15 July 2025 — and the only thing the rename did was give these three a shorter name.',
+      read:{
+        hand:'None of the three fit, and no tool you used changes that. The renderer was never the question at this depth.',
+        mill:'Bucket one. Not because a machine made it — because thirty of them are the same object with the nouns swapped.',
+        oracle:'Bucket three, the only one of the three with a named harm behind it rather than a taste.'
+      },
+      cap:'FIG. 3 — two of the three are judgments; one is a harm.'
+    },
+    {
+      gauge:'−3', jp:'再審査',
+      label:'STRATUM −3 · THE SECOND LOOK', labelJp:'追加審査',
+      body:'Since 10 March 2025, anything first marked Limited or No ad earnings is routed automatically for an additional review that may be completed by a person. Most decisions still land in minutes. Some take up to twenty-four hours.',
+      read:{
+        hand:'Never routed. If this is your carry, you will go your whole career without learning this stratum exists.',
+        mill:'Routed. A person can open it, see the thirty siblings, and decide the thing the first pass structurally could not.',
+        oracle:'Routed, and the wait is the point — a human is the only reviewer who can weigh what presenting as an expert means here.'
+      },
+      cap:'FIG. 4 — the platform paying for a second opinion about you.'
+    },
+    {
+      gauge:'−4', jp:'判定',
+      label:'STRATUM −4 · THE ICON', labelJp:'収益化アイコン',
+      body:'Green, yellow, red. The entire descent, compressed into one glyph in a studio interface, arriving in the hours a video earns most of what it will ever earn.',
+      read:{
+        hand:'Green. Full ad earnings. The rule was satisfied before the upload finished processing.',
+        mill:'Yellow, then a channel-level question the icon cannot show you. Videos are judged one at a time; channels are not.',
+        oracle:'Red, and an appeal that asks you to argue about a category rather than about a frame.'
+      },
+      cap:'FIG. 5 — six strata of reasoning, rendered as one colour.'
+    },
+    {
+      gauge:'−5', jp:'条文',
+      label:'STRATUM −5 · THE RULE', labelJp:'規則そのもの',
+      body:'The floor. A sentence older than every layer above it, and older than the ability to render a convincing face: content must be original and authentic. No new policies were added to the Partner Program.',
+      read:{
+        hand:'You were never in scope. You are still not in scope. Nothing about your Tuesday changed on 15 July.',
+        mill:'You were out of scope in 2019 too. What changed is that it became cheap enough to be out of scope forty times a day.',
+        oracle:'New in practice, old in principle. The principle is that authority has to be earned by somebody, and here there is no somebody.'
+      },
+      cap:'FIG. 6 — the floor was always this. The queue above it is what moved.'
+    }
+  ];
+
+  var RESOLVE = {
+    hand:'Read the letter and you are owed a green icon; work the queue and you get one, usually within the minute. For this carry the two readings agree, which is exactly why this carry never hears about the policy at all.',
+    mill:'Read the letter and nothing changed for you either — this was ineligible in 2019. Work the queue and everything changed, because the volume that makes it obvious is new, and volume is what the second look is looking at.',
+    oracle:'Read the letter and this was always covered by a rule about authenticity. Work the queue and it is the one carry the July rename genuinely sharpened: the third bucket exists because somebody had to name it out loud.'
+  };
+
+  var STOP_H = 168;
+  document.documentElement.style.setProperty('--stop-h', STOP_H + 'px');
+
+  var carry = 'hand', depth = 0, drops = 0, carries = 0, started = Date.now();
+  var gauge = document.getElementById('rq-gauge');
+  var mark = document.getElementById('rq-mark');
+  var list = document.getElementById('rq-strata');
+  var lower = document.getElementById('rq-lower');
+  var resolveEl = document.getElementById('rq-resolve');
+
+  /* Build the gauge rail and the strata. Every stratum and every reading
+     is in the DOM from the first paint; the probe changes emphasis only. */
+  STRATA.forEach(function(s, i){
+    var g = document.createElement('div');
+    g.className = 'rq-gstop';
+    g.dataset.i = i;
+    g.innerHTML = '<span></span><span class="jp"></span>';
+    g.children[0].textContent = s.gauge;
+    g.children[1].textContent = s.jp;
+    gauge.appendChild(g);
+
+    var li = document.createElement('li');
+    li.className = 'rq-stratum';
+    li.dataset.i = i;
+    var h = document.createElement('p');
+    h.className = 'rq-shead';
+    h.appendChild(document.createTextNode(s.label + ' · '));
+    var hj = document.createElement('span');
+    hj.className = 'jp';
+    hj.textContent = s.labelJp;
+    h.appendChild(hj);
+    li.appendChild(h);
+
+    var b = document.createElement('p');
+    b.className = 'rq-sbody';
+    b.textContent = s.body;
+    li.appendChild(b);
+
+    var r = document.createElement('p');
+    r.className = 'rq-sread';
+    var tag = document.createElement('span');
+    tag.className = 'tag';
+    r.appendChild(tag);
+    var txt = document.createTextNode('');
+    r.appendChild(txt);
+    li.appendChild(r);
+    li._tag = tag; li._txt = txt;
+
+    var c = document.createElement('p');
+    c.className = 'rq-scap';
+    c.textContent = s.cap;
+    li.appendChild(c);
+
+    list.appendChild(li);
+  });
+
+  var stops = gauge.querySelectorAll('.rq-gstop');
+  var items = list.querySelectorAll('.rq-stratum');
+
+  function paintCarry(){
+    for (var i = 0; i < STRATA.length; i++){
+      items[i]._tag.textContent = CARRIES[carry];
+      items[i]._txt.nodeValue = STRATA[i].read[carry];
+    }
+    resolveEl.textContent = RESOLVE[carry];
+  }
+
+  function paintDepth(){
+    for (var i = 0; i < items.length; i++){
+      if (i <= depth) items[i].classList.add('lit'); else items[i].classList.remove('lit');
+      if (i === depth) stops[i].classList.add('at'); else stops[i].classList.remove('at');
+    }
+    mark.style.top = (depth * STOP_H + STOP_H / 2 + 6) + 'px';
+    document.getElementById('rq-depth').textContent = depth + ' of 5';
+    lower.textContent = depth >= STRATA.length - 1 ? '★ Raise to the surface' : '★ Lower the probe';
+  }
+
+  document.querySelectorAll('.rq-chip').forEach(function(chip){
+    chip.addEventListener('click', function(){
+      if (chip.dataset.carry === carry) return;
+      carry = chip.dataset.carry;
+      carries++;
+      document.getElementById('rq-carries').textContent = carries;
+      document.querySelectorAll('.rq-chip').forEach(function(c){
+        c.setAttribute('aria-pressed', c.dataset.carry === carry ? 'true' : 'false');
+      });
+      paintCarry();
+    });
+  });
+
+  lower.addEventListener('click', function(){
+    if (depth >= STRATA.length - 1){ depth = 0; }
+    else { depth++; drops++; document.getElementById('rq-drops').textContent = drops; }
+    paintDepth();
+    items[depth].scrollIntoView({ block:'center', behavior: reduced ? 'auto' : 'smooth' });
+  });
+
+  paintCarry();
+  paintDepth();
+
+  /* Session clock. Timer-robust per house law: every tick advances via a
+     rAF-vs-setTimeout race rather than rAF alone, which provably stalls in
+     throttled and background tabs. Nothing here animates a pixel. */
+  var clockEl = document.getElementById('rq-clock'), lastTick = 0;
+  function tick(now){
+    if (now - lastTick > 950){
+      var s = Math.floor((Date.now() - started) / 1000);
+      var m = Math.floor(s / 60);
+      clockEl.textContent = (m < 10 ? '0' : '') + m + ':' + ((s % 60) < 10 ? '0' : '') + (s % 60);
+      lastTick = now;
+    }
+    schedule();
+  }
+  var pending = false;
+  function schedule(){
+    if (pending) return;
+    pending = true;
+    var done = false;
+    function run(t){ if (done) return; done = true; pending = false; tick(t || performance.now()); }
+    requestAnimationFrame(run);
+    setTimeout(run, 1000 + Math.floor(rng() * 60));
+  }
+  schedule();
+})();
+</script>

--- a/src/components/CompareFeature.css
+++ b/src/components/CompareFeature.css
@@ -313,6 +313,96 @@
   text-align: center;
 }
 
+/* ── Works cited — back-of-book grammar, not footnotes ──── */
+.pop-compare-refs {
+  max-width: 640px;
+  margin: 56px auto 0;
+  padding: 28px 0 0;
+  border-top: 1px solid var(--pop-hairline);
+}
+
+.pop-compare-refs-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.pop-compare-refs-note {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--pop-coffee);
+  margin: 4px 0 0;
+  max-width: 52ch;
+}
+
+.pop-compare-refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pop-compare-refs-item {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 8px;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--pop-ink);
+}
+
+.pop-compare-refs-n {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--issue-accent);
+  font-weight: 700;
+  padding-top: 2px;
+}
+
+.pop-compare-refs-authors {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pop-coffee);
+}
+
+.pop-compare-refs-year {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--pop-coffee);
+}
+
+.pop-compare-refs-title {
+  font-style: italic;
+  color: var(--pop-ink);
+}
+
+.pop-compare-refs-journal {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--pop-coffee);
+}
+
+.pop-compare-refs-dot { color: var(--pop-ink); }
+
+/* Ink stock — flip the citation colors for dark paper. */
+.pop-compare.pop-stock-ink .pop-compare-refs { border-top-color: rgba(250, 249, 246, 0.18); }
+.pop-compare.pop-stock-ink .pop-compare-refs-note { color: var(--pop-sepia); }
+.pop-compare.pop-stock-ink .pop-compare-refs-item { color: var(--pop-ivory); }
+.pop-compare.pop-stock-ink .pop-compare-refs-authors,
+.pop-compare.pop-stock-ink .pop-compare-refs-year,
+.pop-compare.pop-stock-ink .pop-compare-refs-journal { color: var(--pop-sepia); }
+.pop-compare.pop-stock-ink .pop-compare-refs-title,
+.pop-compare.pop-stock-ink .pop-compare-refs-dot { color: var(--pop-ivory); }
+
 /* ── Print — both lenses' readings stack per fact ───────── */
 @media print {
   .pop-compare-switch { display: none; }

--- a/src/components/CompareFeature.tsx
+++ b/src/components/CompareFeature.tsx
@@ -149,6 +149,32 @@ export function CompareFeature({ spread, issue }: CompareFeatureProps) {
           </blockquote>
         )}
 
+        {/* ── Works cited (optional) ──────────────────────── */}
+        {spread.references && (
+          <aside className="pop-compare-refs" aria-label="Works cited">
+            <header className="pop-compare-refs-head">
+              <span className="pop-kicker pop-kicker--tomato">{spread.references.kicker}</span>
+              {spread.references.note && (
+                <p className="pop-compare-refs-note">{spread.references.note}</p>
+              )}
+            </header>
+            <ol className="pop-compare-refs-list">
+              {spread.references.items.map((ref, i) => (
+                <li key={i} className="pop-compare-refs-item">
+                  <span className="pop-compare-refs-n">{String(i + 1).padStart(2, '0')}</span>
+                  <span className="pop-compare-refs-body">
+                    <span className="pop-compare-refs-authors">{ref.authors}</span>
+                    <span className="pop-compare-refs-year"> ({ref.year}). </span>
+                    <span className="pop-compare-refs-title">{ref.title}</span>
+                    {ref.journal && <span className="pop-compare-refs-journal">. {ref.journal}</span>}
+                    <span className="pop-compare-refs-dot">.</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </aside>
+        )}
+
         {/* ── Sign-off ────────────────────────────────────── */}
         <footer className="pop-compare-signoff">
           <hr className="pop-rule pop-rule--short pop-rule--tomato" />

--- a/src/content/issues/428.ts
+++ b/src/content/issues/428.ts
@@ -1,0 +1,289 @@
+/* ──────────────────────────────────────────────────────────────
+   ISSUE 428 — MAR 2027
+   NOTHING NEW WAS ADDED
+   何ひとつ新しくはない — 規則は動かず、審査の列だけが動いた
+
+   The second `compare` instance (406 was the first, and remains the
+   only other). Per docs/interaction-language.md rule 7, two
+   instances is the threshold at which a pattern MAY be extracted —
+   this issue deliberately does not extract one. CompareFeature is
+   reused as written; the only change to it is an optional
+   `references` block, which every prior compare (406) is unaffected
+   by because it is optional.
+
+   The material: YouTube's 15 July 2025 monetization update, which
+   renamed the "repetitious content" policy to "inauthentic content"
+   and named three categories that make a channel ineligible. The
+   platform's own framing, repeated in every clarification since:
+   no new policies were added to the Partner Program.
+
+   Why a switch and not an essay: the load-bearing sentence is
+   literally true and practically incomplete, and those are not
+   points on a spectrum. Read as THE LETTER, the July update moved
+   nothing — the eligibility bar is where it always was, generative
+   AI is explicitly not the question, reaction videos with original
+   commentary are untouched. Read as THE QUEUE, a policy lives where
+   it is enforced, and the update handed the review stack three new
+   handles, two of which ("generic", "off-putting") are affective
+   judgments made at a scale only a classifier can serve. Both
+   readings survive the same six facts. There is no blended reading
+   that is sixty per cent letter and forty per cent queue.
+
+   Unlike 406, this piece DOES give a verdict. 406 declined because
+   both of its readings had equal claim on the same day; here they
+   do not — they answer different questions (what you are owed
+   versus what you will meet), and saying so is the honest
+   resolution rather than a false symmetry.
+
+   Every fact is externally sourced and dated; the six citations are
+   filed in the spread's own references block, which is what the
+   `references` field was added to CompareSpread for. No fact is
+   invented for symmetry, and no reading is written as a strawman —
+   THE LETTER is argued as the platform would argue it.
+
+   Identity decisions:
+     • coverStock = 'cream' — the anchor stock, unused across the
+       419–427 run. The plainest paper in the cabinet for the least
+       novel policy update: the material makes the argument before
+       the headline does.
+     • coverLayout = 'classic' — the switch lives inside the spread;
+       the cover has no apparatus to stage.
+     • coverSeal = NO NEW POLICIES · III·27 — the signature move.
+       The platform's own sentence, stamped as a rubber seal, in the
+       corner where a reader expects an embargo notice. The stamp
+       is the claim the whole issue is a reading of.
+     • accent = 'brick' — deeper, archival, record-of-record. Unused
+       in the 419–427 run, and the correct register for a piece
+       whose subject is a text rather than an event.
+     • spread.type = 'compare', spread.stock = 'cream'.
+
+   Artifact edition: artifacts/428-nothing-new-was-added.html —
+   THE REVIEW QUEUE, a six-stratum descent of one upload from the
+   file to the rule that judges it. The depth axis (artifact-
+   language §III) is the review stack itself, which the spread has
+   no room for: the spread argues the text, the artifact lowers a
+   probe through the machinery the text runs on. Carried context is
+   the upload's character, chosen at the surface, re-inking every
+   stratum below it. What the reduction gives up: the descent, the
+   gauge, and the three-way carry — the spread keeps the binary
+   because the binary is the argument.
+   ────────────────────────────────────────────────────────────── */
+
+import type { IssueRecord } from './index'
+
+export const ISSUE_428: IssueRecord = {
+  number: '428',
+  month: 'MAR',
+  year: '2027',
+  feature: 'NOTHING NEW WAS ADDED',
+  featureJp: '何ひとつ新しくはない',
+  price: '¥0 · BYOK',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
+
+  coverStock: 'cream',
+  coverLayout: 'classic',
+
+  coverSeal: {
+    label: 'NO NEW POLICIES',
+    date: 'III·27',
+  },
+
+  accent: 'brick',
+
+  headline: {
+    prefix: 'Nothing',
+    emphasis: 'New',
+    suffix: ' Was Added.',
+    swash: 'A platform renamed one policy and half the internet read a ban. The text moved nothing. The review queue moved anyway. Six facts, read both ways, on a switch.',
+  },
+
+  coverDeck:
+    'A platform renamed one policy and half the internet read a ban. Six facts, read both ways.',
+
+  contents: [
+    { n: '001', en: 'A rename that renamed nothing', jp: '名を変えただけの改訂', tag: 'POLICY' },
+    { n: '002', en: 'The sentence nobody finished reading', jp: '誰も読み終えなかった一文', tag: 'FACT' },
+    { n: '003', en: 'The three that lose the money', jp: '収益を失う三分類', tag: 'FACT' },
+    { n: '004', en: 'The tool was never the question', jp: '道具は問題ではなかった', tag: 'FACT' },
+    { n: '005', en: 'Reactions were never the target', jp: 'リアクションは的ではない', tag: 'FACT' },
+    { n: '006', en: 'The second look, and the wait', jp: '再審査と、その待ち時間', tag: 'QUEUE' },
+  ],
+
+  spread: {
+    type: 'compare',
+    kicker: 'THE SWITCH · 二読',
+    title: 'Nothing New Was Added.',
+    titleJp: '何ひとつ新しくはない。',
+    deck: 'On 15 July 2025 a platform renamed one policy and published a sentence: no new policies were added to the Partner Program. It is true. It is also the least useful true sentence of that year. Read as THE LETTER, the rules stand exactly where they stood. Read as THE QUEUE, three new words entered the machinery that decides what your upload earns. Same six facts. Flip the switch.',
+    byline: 'BY THE EDITORS · KERNEL.CHAT',
+    stock: 'cream',
+
+    intro: [
+      {
+        heading: 'A clarification is not nothing',
+        headingJp: '明確化は、無ではない',
+        paragraphs: [
+          'The update was small enough to be a footnote. A policy called "repetitious content" — in force since long before a model could render a face — became a policy called "inauthentic content", and three categories were spelled out underneath it: content that is generic, templated, or mass-produced; content that is off-putting or distressing; and synthetic personas presenting as authorities on health, finance, law, or politics. The platform said, in as many words, that nothing had been added to the Partner Program. Every clarification since has said it again.',
+          'And the creator internet read a ban on AI. Not because anyone lied, but because a rule and its enforcement are two different objects, and only one of them was published. The text is a promise about what you are owed. The queue is a description of what you will meet. This piece holds both, on a switch, because there is no reading that is part-way between a promise and a description — the honest move is to give the reader all six facts under one lens, then all six under the other.',
+        ],
+      },
+    ],
+
+    lenses: [
+      {
+        id: 'letter',
+        label: 'THE LETTER',
+        labelJp: '条文',
+        stance:
+          'Read the text as written and nothing moved: a rename of a guideline already in force, tool-agnostic by design, with the eligibility bar exactly where it has always been.',
+      },
+      {
+        id: 'queue',
+        label: 'THE QUEUE',
+        labelJp: '審査',
+        stance:
+          'A policy lives where it is enforced. Three new words entered a review stack that runs at platform scale, and a new word is a new handle — whatever the changelog says.',
+      },
+    ],
+
+    defaultLens: 'letter',
+
+    facts: [
+      {
+        fact: 'On 15 July 2025 the "repetitious content" policy was renamed "inauthentic content".',
+        factJp:
+          '2025年7月15日、「繰り返しの多いコンテンツ」の規定が「本物ではないコンテンツ」に改称された。',
+        readingA:
+          'A minor update to a longstanding guideline, in the platform\'s own words. Content of this kind has never been eligible for monetization; the rename makes the existing bar easier to describe to the people it applies to.',
+        readingB:
+          'The old name described a measurable property — a thing repeats or it does not. The new one names a judgment. "Repetitious" is something you can count; "inauthentic" is something somebody has to decide about you.',
+      },
+      {
+        fact: 'The platform stated that no new policies were added to the Partner Program.',
+        factJp:
+          'YouTubeは、パートナープログラムに新しい規則は一切追加していないと述べた。',
+        readingA:
+          'Literally true and worth taking at face value. Nobody\'s eligibility changed on 15 July. A channel that was monetizable on the fourteenth was monetizable on the sixteenth, under the same standard, for the same reasons.',
+        readingB:
+          'That sentence was published because a very large number of creators had already concluded otherwise. A clarification issued into a panic is evidence that the enforcement was being felt before the wording changed — which is the whole disagreement, stated by the platform, in the platform\'s own reassurance.',
+      },
+      {
+        fact: 'Three categories were named as ineligible: generic or repetitive content; off-putting or distressing content; and AI personas presenting as experts on sensitive topics such as health, finance, law, or politics.',
+        factJp:
+          '収益化の対象外となる三つの分類が名指しされた。定型的・反復的なもの、不快なもの、そして健康・金融・法律・政治といった重要な話題で専門家を装う合成人格である。',
+        readingA:
+          'Each is a specific, describable failure, and the third is the one that matters most: a synthetic figure claiming medical or financial authority is a harm with a name, not an aesthetic complaint. None of the three is a rule about a tool.',
+        readingB:
+          'Two of the three are affective judgments. "Generic" and "off-putting" are the kind of call a person makes in a second and a classifier makes a million times a day, and neither of them can show its work. A creator cannot appeal a vibe.',
+      },
+      {
+        fact: 'The policy is tool-agnostic: it applies the same way to generative AI, CGI, stock footage, and a camera.',
+        factJp:
+          '規定は道具を問わない。生成AIも、CGIも、ストック映像も、カメラも同じ扱いである。',
+        readingA:
+          'AI was never the question, and the platform ships AI tools of its own. What is asked for is unique human contribution — voice, editing, structure, a point of view — and content that has it stays eligible no matter what rendered the frames.',
+        readingB:
+          'Tool-agnostic is a claim about the rule, not about the distribution of what arrives. The content most likely to be generic at scale is the content that became cheapest to produce, so a neutral rule lands unevenly on purpose — and the creators it lands on are the ones who were told the tool is fine.',
+      },
+      {
+        fact: 'The reused-content policy did not change. Commentary, clips, compilations, and reaction videos are reviewed as they were before.',
+        factJp:
+          '再利用コンテンツの規定に変更はない。解説、切り抜き、まとめ、リアクションは従来どおり審査される。',
+        readingA:
+          'The clearest correction of the July misreading. A reaction video carrying original commentary was monetizable before and is monetizable after; what was disqualified is a bare repost of someone else\'s work, which was already disqualified.',
+        readingB:
+          '"As before" is both the reassurance and the problem. Reused-content review was already the least predictable surface on the platform, and this update pointed a great deal of new attention at it while changing none of the machinery that made it unpredictable.',
+      },
+      {
+        fact: 'Since 10 March 2025, a video first assigned "Limited" or "No ad earnings" is routed for an additional review that may be completed by a human. Most decisions still land in minutes; some take up to 24 hours.',
+        factJp:
+          '2025年3月10日以降、当初「制限付き」または「収益化なし」と判定された動画は、人間が担当しうる追加審査へ自動的に回される。大半は数分で決まるが、最大で24時間かかる場合もある。',
+        readingA:
+          'The platform spending real money to be more right. A person sees the full context of a video and can weigh cultural difference in a way the first-pass classifier cannot, and the stated purpose is to raise monetization potential, not lower it.',
+        readingB:
+          'It is also the platform conceding, in a product change, that the automated pass is wrong often enough to need a second one. The relief is genuine and it arrives as a wait — and a video earns most of what it will ever earn in the hours that wait is running.',
+      },
+    ],
+
+    verdict:
+      'Both readings are true and they are not symmetrical, because they answer different questions. THE LETTER is what the platform owes you and will defend. THE QUEUE is what your upload will actually meet on a Tuesday. Read the letter so you know what is being promised; build for the queue, because that is the thing that pays.',
+
+    outro: [
+      {
+        heading: 'Where a rule actually lives',
+        headingJp: '規則が実際に住む場所',
+        paragraphs: [
+          'The practical instruction survives the disagreement intact, which is how you know it is the real one. Put something in the video that could only have come from you — a voice, a cut, an argument, a mistake — and it does not matter what rendered the frames. That was the rule in 2019 and it is the rule now. The July update did not invent it; it wrote it down in a way that finally scared people into reading it.',
+          'What the update did change is the vocabulary the machinery has to work with. "Repetitious" was a property of a file. "Inauthentic" is a verdict about a person. Nothing in the changelog moved, and something in the room did — and a magazine that files an audit with every issue is not in a position to pretend those are the same thing.',
+        ],
+      },
+    ],
+
+    references: {
+      kicker: 'THE POLICY FILE · 出典',
+      note: 'Every fact above, with where it came from. Six claims, six citations, all read before the issue was set.',
+      items: [
+        {
+          authors: 'YouTube Help',
+          year: '2025',
+          title: 'YouTube channel monetization policies',
+          journal: 'support.google.com/youtube/answer/1311392',
+        },
+        {
+          authors: 'YouTube Help',
+          year: '2025',
+          title: 'Understanding additional reviews for ad monetization',
+          journal: 'support.google.com/youtube/answer/16271309',
+        },
+        {
+          authors: 'Social Media Today',
+          year: '2025',
+          title: 'YouTube Clarifies Changes to Monetization Rules Around Inauthentic Content',
+          journal: 'socialmediatoday.com, 8 July 2025',
+        },
+        {
+          authors: 'PPC Land',
+          year: '2025',
+          title: 'YouTube clarifies "inauthentic content" policy changes',
+          journal: 'ppc.land',
+        },
+        {
+          authors: 'Search Engine Journal',
+          year: '2025',
+          title: 'YouTube Targets Mass-Produced Content In Monetization Update',
+          journal: 'searchenginejournal.com',
+        },
+        {
+          authors: 'Tubefilter',
+          year: '2025',
+          title: 'YouTube thinks a more human touch will cut down on demonetization mistakes',
+          journal: 'tubefilter.com, 11 March 2025',
+        },
+      ],
+    },
+
+    pullQuote: {
+      text: '"Repetitious" was a property of a file. "Inauthentic" is a verdict about a person.',
+      attribution: 'THE SWITCH DESK · 428',
+    },
+
+    signoff: '街のコーダーたちへ — read the letter, then build for the queue.',
+  },
+
+  audit: {
+    drafted: 'magazine-editor session, III·27',
+    verified: 'six claims, six citations — all sourced before the issue was set',
+    adherence: 'CompareSpread, second instance · no pattern extracted (rule 7)',
+    readCut: 'six facts, twelve readings · no fact invented for symmetry',
+    pressed: 'III·27 · artifact edition 428-nothing-new-was-added',
+  },
+
+  credits: {
+    editorInChief: 'Isaac Hernandez',
+    creativeDirection: 'kernel.chat group',
+    artDirection: 'in-house',
+    copy: 'kernel.chat editorial',
+    japanese: 'kernel.chat editorial',
+    production: 'kernel.chat group',
+  },
+}

--- a/src/content/issues/PUBLISHING.md
+++ b/src/content/issues/PUBLISHING.md
@@ -84,7 +84,7 @@ Pick the editorial tool that fits the content:
 | `review` | Graded surveys — "we tested N things, here's the ranking" | Top-line verdict, numbered rubric, graded subject cards, optional standout award |
 | `colloquy` | A single argument carried by **two co-equal voices** (no host) | Voices legend (two stances), numbered movements of attributed turns, optional terms dossier + pull quote. The two voices are positions, not people — a private conversation is mined, never transcribed (see 398). |
 | `instrument` | A **calibrated control handed to the reader** — the interactive tool | Fixed prompt; N dial stops (roving radiogroup); the same prompt answered at each depth with a meter line. Interaction is React state; motion stays CSS-only; all panels stay in the DOM and print renders them stacked. Meter readings must be honestly labelled when representative, or genuinely measured (see 399, 405). |
-| `compare` | A **binary switch between two irreducible lenses** on one fact set — not depths, positions with no medium between them | Two-lens switch (ARIA `role="switch"`, not radiogroup); a shared fact list, each fact read differently under each lens; optional verdict, left undefined when the piece declines to resolve (see 406). |
+| `compare` | A **binary switch between two irreducible lenses** on one fact set — not depths, positions with no medium between them | Two-lens switch (ARIA `role="switch"`, not radiogroup); a shared fact list, each fact read differently under each lens; optional verdict, left undefined when the piece declines to resolve (see 406), or given when the two lenses answer different questions rather than the same one (see 428). Optional `references` block at the foot for a compare over externally sourced facts (added 428). |
 | `sequence` | A **real ordered process in discrete, complete stages** — each stage's account depends on the one before it, not a spectrum or a binary | Numbered rail (ARIA `role="tablist"`/`tab`/`tabpanel`, standard Tabs keyboard behaviour, no forward-lock); a panel per stage with an optional artifact line; the final stage may attach the process's real terminal outcomes. All stages stay in the DOM and print renders them stacked, in order (see 408). |
 | `galley` | A **text the reader marks up** — N independent strike/stet marks on the prose itself; the reader performs an editorial act, and any feeling it produces stays unclaimed | One `aria-pressed` toggle per passage (stable accessible name; visible mark swaps CUT → STET); struck text stays legible in the DOM (strikethrough, never removal); a live tally counts ONLY the reader's marks, with a mandatory `tallyNote` stating what is counted and that marks are unrecorded, session-only. Print hides the knives and keeps the marks (see 410). |
 | `tutor` | A **manual that teaches the interaction grammar** — the reader operates a stakes-free version of each shape and becomes literate in all of them; a composite, not a fifth primitive | An array of `lessons`, one per shape (`dial`/`switch`/`sequence`/`galley`), each with a `teaches` line, `intro`, an operable practice control using that shape's real ARIA pattern, and a `consequence` line (always visible — rule 1). Teach by consequence, never by grade: no control is ever "wrong." Controls reimplemented inline, not imported (rule 7). Print shows every reading, hides every control (see 411). |
@@ -215,7 +215,7 @@ recent same-format issue (`371.ts` for essay-as-profile,
 `405.ts` for instrument (interactive dial, measured meter) or
 `416.ts` for instrument (a *register* dial rather than effort — a real local
 model run three ways; adds the optional `dialLabel` field),
-`406.ts` for compare (interactive binary switch — first instance),
+`428.ts` for compare (interactive binary switch — second instance, sourced facts + references; `406.ts` is the first),
 `408.ts` for sequence (interactive ordered stages — first instance),
 `410.ts` for galley (interactive reader-markup — first instance),
 `411.ts` for tutor (interactive manual teaching all four shapes — first instance),
@@ -503,7 +503,17 @@ branch — only main publishes.
 
 ---
 
-_Last updated: ISSUE 427 · FEB 2027 (THE MOAT IS REALITY — the
+_Last updated: ISSUE 428 · MAR 2027 (NOTHING NEW WAS ADDED — the
+second `compare` instance, and the first over externally sourced
+material: YouTube's 15 July 2025 "inauthentic content" rename, six
+cited facts read under THE LETTER and THE QUEUE. Adds an optional
+`references` block to CompareSpread (406 unaffected) and, unlike
+406, gives a verdict — the two lenses answer different questions, so
+declining would have been a false symmetry. Artifact edition
+`428-nothing-new-was-added.html` carries the depth axis the spread
+has no room for: a six-stratum descent of one upload through the
+review stack, with the upload's character as carried context. Prior:
+427 THE MOAT IS REALITY — the
 second `interview` instance, and the first with a real named subject
 (Alex Hormozi) rather than a composite. Nine exchanges trimmed, not
 invented, from a reader-supplied transcript of a real broadcast

--- a/src/content/issues/index.ts
+++ b/src/content/issues/index.ts
@@ -80,6 +80,7 @@ import { ISSUE_424 } from './424'
 import { ISSUE_425 } from './425'
 import { ISSUE_426 } from './426'
 import { ISSUE_427 } from './427'
+import { ISSUE_428 } from './428'
 
 // Re-export accent types so issue files can import from a single place.
 export type { IssueAccent, InkSeedName, InkSeed } from './accents'
@@ -163,6 +164,7 @@ export const ALL_ISSUES: IssueRecord[] = [
   ISSUE_425,
   ISSUE_426,
   ISSUE_427,
+  ISSUE_428,
 ]
 
 /** The latest published issue — drives the landing cover. */

--- a/src/content/issues/schema.ts
+++ b/src/content/issues/schema.ts
@@ -609,6 +609,11 @@ export interface CompareSpread extends SpreadCommon {
   verdict?: string
   outro?: SpreadSection[]
   pullQuote?: SpreadPullQuote
+  /** Optional works-cited block at the foot — reused from the essay
+   *  toolkit. Added for ISSUE 428, whose six facts are all external
+   *  and dated; optional, so 406 is unaffected. A compare over
+   *  sourced material should print where the facts came from. */
+  references?: SpreadReferences
 }
 
 /** ─── sequence ──────────────────────────────────────────────────


### PR DESCRIPTION
## What

Presses **ISSUE 428 · MAR 2027 — NOTHING NEW WAS ADDED** (何ひとつ新しくはない), a `compare` spread on YouTube's 15 July 2025 "inauthentic content" rename, plus its artifact edition.

- `src/content/issues/428.ts` — the issue: cream stock, classic layout, brick accent, `coverSeal` **NO NEW POLICIES · III·27**. Six externally-sourced facts read under two lenses (**THE LETTER** / **THE QUEUE**), a verdict, a references block.
- `artifacts/428-nothing-new-was-added.html` — the artifact edition: **THE REVIEW QUEUE**, a six-stratum descent from the uploaded file to the rule that judges it.
- `src/content/issues/schema.ts` — `CompareSpread` gains an optional `references?: SpreadReferences`.
- `src/components/CompareFeature.{tsx,css}` — renders that block under `pop-compare-refs` (ink-stock variants and print included).
- `src/content/issues/index.ts` — registration; `LATEST_ISSUE` flips to 428.
- `src/content/issues/PUBLISHING.md` — §III.2 compare row, §IV template pointer, and the "Last updated" line (the §IX hygiene pass).
- `SCRATCHPAD.md` — session entry.

## Why

The material is a policy update that almost everyone read wrong: the platform renamed one guideline, named three ineligible categories, and stated plainly that no new policies were added to the Partner Program — and the creator internet read a ban on AI. Both halves of that are true and they pull against each other, which is exactly the shape `compare` exists for.

Read as **THE LETTER**, nothing moved: a rename of a guideline older than generative video, tool-agnostic by design, with the reused-content policy (commentary, clips, reactions) untouched. Read as **THE QUEUE**, three new words entered a review stack running at platform scale, and two of them — "generic", "off-putting" — are affective calls a classifier cannot show its work on. There is no blended reading that is sixty per cent letter and forty per cent queue.

## How

**Why a second `compare` and not an essay.** A dial holds N positions on one variable; these are two complete accounts of the same six facts. Per `docs/interaction-language.md` rule 7, instance two is the threshold at which a pattern *may* be extracted — this deliberately does not extract one. `CompareFeature` is reused as written.

**Why this one gives a verdict and 406 did not.** 406 declined because both readings had equal claim on the same day. Here they answer *different questions* — what the platform owes you versus what your upload meets on a Tuesday — so declining would have been a false symmetry rather than honesty. No reading is written as a strawman; THE LETTER is argued as the platform would argue it, and no fact is invented for symmetry.

**Why the schema grew.** Every fact is external and dated, so the spread needed somewhere to print its sources. `references` is optional, so 406 is unaffected; the CSS is self-contained in `CompareFeature.css` rather than borrowed from `EssayFeature.css`, so a reader landing directly on `/issues/428` gets it styled.

**Sources** (all read before the issue was set, cited in the spread's own policy file): the platform's monetization-policy and additional-reviews help pages, Social Media Today, PPC Land, Search Engine Journal, Tubefilter.

**Artifact edition** (PUBLISHING.md §V.5, `docs/artifact-language.md` §III). The spread argues the text; the artifact lowers a probe through the machinery the text runs on — upload → classifier → three buckets → second look → icon → the rule. Named depth axis with a real gauge; carried context (the upload's character, three authored composites, re-inks every stratum below); a floor that resolves per carry; every stratum legible at rest, so the probe raises emphasis and never conjures a layer. Seed **428-0715** printed on the masthead, timer-robust clock via the rAF-vs-setTimeout race, reduced-motion collapse, print stacks all six strata with the controls removed. What the reduction to the spread gives up — the descent, the gauge, and the three-way carry — is filed in the issue's header comment.

Filed at `artifacts/428-nothing-new-was-added.html`; **not** published to the claude.ai artifact surface — that stays the editor's call.

## Testing

- [x] `npm run build` passes
- [x] `npx vitest run` passes — 811/811 across 51 files
- [x] `npx tsc --noEmit` passes (via `npm run build`; a bare global `tsc` reports pre-existing `tsconfig.json` deprecation errors on a clean tree too, unrelated to this change)
- [x] `node scripts/check-editorial.mjs` — clean, 69 issues scanned (artifact-first, no POPEYE naming, no emoji)
- [x] `node scripts/check-adherence.mjs` — clean, 0 raw hex across 32 files
- [ ] Visual preview at `/`, `/issues/428`, `/issues/427`, and ≤640px — not run in this environment

**Not deployed.** This is a feature branch; only a push to `main` publishes (PUBLISHING.md §VII).

## Screenshots

None — no dev server was run in this session. The cover, the switch at both lenses, and the artifact's six strata are worth an eye before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVhimSGzN5fdMspNJKebYn)_