### PR TITLE
ISSUE 428 — THE ONE PERCENT

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -2,6 +2,29 @@
 
 > This file persists context between Claude Code sessions.
 
+## Session 2026-08-05 — ISSUE 428 "THE ONE PERCENT" drafted on branch
+
+**Branch:** `claude/youtube-ai-slop-detection-ckgsez` (not merged to main;
+nothing live until main takes it).
+
+A `dispatch` on the video platform's cluster-termination sweep, filed
+from a reader-supplied transcript of a video commentary: the Google
+SCCTS paper (50,000 clusters, ~130,000 channels terminated, appeal
+overturn under 1%), the Kurzgesagt false positive (25M subs, human-made,
+throttled by AI detection, repaired via platform contacts), and the
+access asymmetry for creators without those contacts. Doctrine filed:
+measure the detector at its appeal desk, not its precision figure.
+
+Identity: ledger stock + ledger-rule layout + graphite accent (372's
+audit-register precedent); seal TERMINATED · OVERTURNED; bridge to 417.
+Artifact edition drafted first at `artifacts/428-the-one-percent.html` —
+operable sweep field, 400 seeded channels (seed 428-0805 printed),
+threshold radiogroup with authored hit rates disclosed, claims register
+citing sources at the floor. Registered in index.ts; tsc clean (local
+TS 5.9.3 — the global 6.0.2 emits pre-existing tsconfig deprecation
+noise, ignore it), vite build clean, 145 registry tests pass.
+PUBLISHING.md hygiene pass done (§IV dispatch example → 428, footer).
+
 ## Session 2026-07-30 (late) - "You Are Not Finished" WRITTEN AND SHIPPED
 
 **Live:** https://youtu.be/yEeL5u4nwNw - 7:01, public. Shorts on YouTube

--- a/artifacts/428-the-one-percent.html
+++ b/artifacts/428-the-one-percent.html
@@ -1,0 +1,366 @@
+<style>
+  /* ISSUE 428 — THE ONE PERCENT · 一パーセント
+     Single-file artifact edition. Tokens mirrored from src/index.css.
+     Accent: graphite (audit seed) on ledger stock — the sweep is a register.
+     Simulation drawn in-house; the register at the floor cites public
+     reporting, printed as claims with sources. Seed prints. */
+  :root{
+    --ink:#1F1E1D; --ivory:#FAF9F6; --ledger:#F2EFE2;
+    --graphite:#5A5A56; --graphite-deep:#3C3C39; --graphite-lift:#8B8B85;
+    --alarm:#8C3B2E;
+    --hair:rgba(31,30,29,.16); --hair-strong:rgba(31,30,29,.5);
+    --serif:"EB Garamond","Iowan Old Style",Palatino,Georgia,serif;
+    --mono:"Courier Prime","Courier New",monospace;
+    --jp:"Noto Serif JP","Hiragino Mincho ProN","Yu Mincho",serif;
+  }
+  .op-root{background:var(--ledger);color:var(--ink);font-family:var(--serif);
+    margin:0;min-height:100svh;position:relative;overflow-x:hidden;
+    background-image:repeating-linear-gradient(0deg,transparent 0 27px,rgba(31,30,29,.045) 27px 28px)}
+  .op-root *{box-sizing:border-box}
+  .op-frame{position:relative;max-width:1020px;margin:0 auto;padding:0 clamp(16px,4vw,44px)}
+
+  .op-mast{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+    padding:20px 0 14px;border-bottom:1px solid var(--hair-strong);
+    font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;text-transform:uppercase}
+  .op-mast b{color:var(--graphite-deep);font-weight:400}
+  .op-seed{opacity:.6}
+
+  .op-hero{padding:clamp(30px,6vh,60px) 0 8px}
+  .op-kicker{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;color:var(--graphite-deep)}
+  .op-kicker::before{content:"[ "}.op-kicker::after{content:" ]"}
+  .op-hero h1{font-size:clamp(2.4rem,7.4vw,5.2rem);line-height:.98;letter-spacing:-.025em;
+    margin:.32em 0 .12em;font-weight:700;text-wrap:balance}
+  .op-hero h1 em{font-style:italic;color:var(--graphite)}
+  .op-jp{font-family:var(--jp);font-size:clamp(.9rem,2vw,1.15rem);color:var(--graphite);opacity:.9}
+  .op-deck{max-width:60ch;font-size:1.05rem;line-height:1.62;margin:1.2em 0 0}
+
+  .op-gauge{display:flex;flex-wrap:wrap;gap:10px 26px;align-items:baseline;margin:26px 0 12px;
+    font-family:var(--mono);font-size:.7rem;letter-spacing:.1em;text-transform:uppercase}
+  .op-gauge span b{color:var(--graphite-deep);font-weight:400;font-variant-numeric:tabular-nums}
+  .op-gauge .fp b{color:var(--alarm)}
+
+  fieldset.op-dial{border:1px solid var(--hair-strong);margin:0 0 16px;padding:12px 14px}
+  .op-dial legend{font-family:var(--mono);font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--graphite-deep);padding:0 6px}
+  .op-dial [role="radio"]{font-family:var(--mono);font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;
+    background:none;border:1px solid var(--graphite);color:var(--graphite-deep);
+    padding:11px 16px;min-height:44px;margin:0 8px 6px 0;cursor:pointer}
+  .op-dial [role="radio"][aria-checked="true"]{background:var(--graphite-deep);color:var(--ivory)}
+  .op-dial [role="radio"]:focus-visible{outline:2px solid var(--graphite-deep);outline-offset:3px}
+  .op-dial small{display:block;font-family:var(--mono);font-size:.6rem;letter-spacing:.06em;opacity:.65;margin-top:4px;max-width:60ch}
+
+  .op-field{border:1px solid var(--hair-strong);background:rgba(250,249,246,.55);
+    padding:18px;margin:0 0 14px;position:relative}
+  .op-field .tick{position:absolute;width:9px;height:9px;border:1px solid var(--graphite-deep)}
+  .tick.tl{top:-1px;left:-1px;border-right:0;border-bottom:0}
+  .tick.tr{top:-1px;right:-1px;border-left:0;border-bottom:0}
+  .tick.bl{bottom:-1px;left:-1px;border-right:0;border-top:0}
+  .tick.br{bottom:-1px;right:-1px;border-left:0;border-top:0}
+  .op-grid{display:grid;grid-template-columns:repeat(20,1fr);gap:6px}
+  .op-ch{aspect-ratio:1;border:1px solid var(--graphite-lift);background:var(--ivory);position:relative}
+  .op-ch[data-kind="farm"]{background:repeating-linear-gradient(45deg,#DDD9CB 0 3px,var(--ivory) 3px 6px)}
+  .op-ch[data-kind="human"]{background:var(--ivory)}
+  .op-ch[data-kind="human"]::after{content:"";position:absolute;inset:28%;border-radius:50%;background:var(--graphite-deep)}
+  .op-ch[data-state="swept"]{background:var(--graphite-deep);border-color:var(--graphite-deep)}
+  .op-ch[data-state="swept"]::after{background:var(--ledger)}
+  .op-ch[data-state="swept"][data-kind="human"]{background:var(--alarm);border-color:var(--alarm)}
+  .op-legend{display:flex;flex-wrap:wrap;gap:8px 22px;margin-top:12px;
+    font-family:var(--mono);font-size:.6rem;letter-spacing:.1em;text-transform:uppercase}
+  .op-legend i{display:inline-block;width:11px;height:11px;border:1px solid var(--graphite-lift);
+    vertical-align:-1px;margin-right:6px;font-style:normal}
+  .op-legend .l-farm i{background:repeating-linear-gradient(45deg,#DDD9CB 0 3px,var(--ivory) 3px 6px)}
+  .op-legend .l-human i{background:var(--ivory);position:relative}
+  .op-legend .l-swept i{background:var(--graphite-deep);border-color:var(--graphite-deep)}
+  .op-legend .l-fp i{background:var(--alarm);border-color:var(--alarm)}
+
+  .op-probe{display:flex;flex-wrap:wrap;align-items:center;gap:14px;margin:0 0 30px}
+  .op-probe button{font-family:var(--mono);font-size:.72rem;letter-spacing:.14em;text-transform:uppercase;
+    background:none;border:1px solid var(--graphite-deep);color:var(--graphite-deep);
+    padding:15px 24px;min-height:44px;cursor:pointer;transition:transform .14s cubic-bezier(.2,1.6,.4,1),background .14s,color .14s}
+  .op-probe button:hover{background:var(--graphite-deep);color:var(--ivory)}
+  .op-probe button:active{transform:scale(.96)}
+  .op-probe button:focus-visible{outline:2px solid var(--graphite-deep);outline-offset:3px}
+  .op-probe button[disabled]{opacity:.45;cursor:default}
+  .op-probe small{font-family:var(--mono);font-size:.62rem;letter-spacing:.08em;opacity:.65;max-width:46ch}
+
+  .op-prose{max-width:62ch;font-size:1.02rem;line-height:1.66;margin:34px 0}
+  .op-prose p{margin:0 0 1em}
+  .op-prose p:first-child::first-letter{font-size:3.1em;float:left;line-height:.82;
+    padding:.06em .12em 0 0;color:var(--graphite-deep)}
+
+  .op-ledgerlist{border-top:1px solid var(--hair-strong);margin-top:6px;padding-top:14px}
+  .op-ledgerlist h2,.op-reg h2{font-family:var(--mono);font-size:.66rem;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--graphite-deep);font-weight:400;margin:0 0 10px}
+  .op-ledgerlist ul{list-style:none;margin:0;padding:0;font-family:var(--mono);font-size:.7rem;line-height:2;
+    font-variant-numeric:tabular-nums}
+  .op-ledgerlist li{border-bottom:1px dashed var(--hair);display:flex;justify-content:space-between;gap:12px}
+  .op-ledgerlist .empty{opacity:.5;font-style:italic;border:0}
+
+  .op-reg{background:var(--ink);color:var(--ivory);margin:52px calc(50% - 50vw) 0;padding:44px 0 30px}
+  .op-reg .op-frame{max-width:1020px}
+  .op-reg h2{color:var(--graphite-lift)}
+  .op-reg .note{font-size:.98rem;line-height:1.6;max-width:60ch;margin:0 0 20px}
+  .op-rtable{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:.72rem;font-variant-numeric:tabular-nums}
+  .op-rtable th{font-weight:400;letter-spacing:.14em;text-transform:uppercase;font-size:.58rem;
+    text-align:left;color:var(--graphite-lift);border-bottom:1px solid rgba(250,249,246,.7);padding:5px 12px 5px 0}
+  .op-rtable td{border-bottom:1px dashed rgba(250,249,246,.22);padding:6px 12px 6px 0;vertical-align:top}
+  .op-rtable td:first-child{white-space:nowrap;color:var(--graphite-lift)}
+  .op-reg .wrap{overflow-x:auto}
+
+  .op-colophon{padding:40px 0 48px;font-family:var(--mono);font-size:.64rem;
+    letter-spacing:.08em;line-height:2;opacity:.82}
+  .op-colophon b{color:var(--graphite-deep);font-weight:400}
+  .op-glyph{color:var(--graphite-deep)}
+
+  @media (max-width:700px){.op-grid{grid-template-columns:repeat(10,1fr)}}
+  @media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+  @media print{
+    .op-root{background:#fff}
+    .op-dial,.op-probe{display:none}
+    .op-reg{margin:24px 0 0;background:none;color:var(--ink)}
+    .op-rtable th{color:var(--graphite-deep);border-color:var(--ink)}
+    .op-rtable td{border-color:rgba(31,30,29,.3)}
+    .op-rtable td:first-child{color:var(--graphite-deep)}
+  }
+</style>
+
+<div class="op-root" id="op-root">
+<div class="op-frame">
+
+  <header class="op-mast">
+    <span>KERNEL.CHAT · ISSUE <b>428</b> · MAR 2027</span>
+    <span class="op-glyph">★</span>
+    <span class="op-seed">SEED 428-0805 · PRINTED</span>
+  </header>
+
+  <section class="op-hero">
+    <p class="op-kicker">DISPATCH · 速報 · THE PLATFORM DESK</p>
+    <h1>The one <em>percent.</em></h1>
+    <p class="op-jp">一パーセント — 検出器の誠実さは控訴窓口で測る</p>
+    <p class="op-deck">A video platform's classifier learned to terminate channels by the
+    neighbourhood — shared behaviour, shared upload rhythm, shared infrastructure — and
+    swept a hundred and thirty thousand of them. Its appeal-overturn rate is under one
+    percent, and one percent of an industrial sweep is still a street of real people.
+    The field below is yours to sweep. Choose a threshold, run the classifier, and read
+    what the tally calls the remainder.</p>
+  </section>
+
+  <div class="op-gauge" aria-live="polite">
+    <span>SWEEPS RUN <b id="op-runs">0</b></span>
+    <span>CHANNELS SWEPT <b id="op-swept">0</b></span>
+    <span class="fp">HUMANS SWEPT <b id="op-fp">0</b></span>
+  </div>
+
+  <fieldset class="op-dial">
+    <legend>Threshold · 閾値 — carried into every sweep below</legend>
+    <div role="radiogroup" aria-label="Classifier threshold" id="op-thresh">
+      <button type="button" role="radio" aria-checked="false" data-t="lenient" tabindex="-1">LENIENT · farms slip through</button>
+      <button type="button" role="radio" aria-checked="true" data-t="standard" tabindex="0">STANDARD · the published posture</button>
+      <button type="button" role="radio" aria-checked="false" data-t="strict" tabindex="-1">STRICT · humans get caught</button>
+    </div>
+    <small>The trade is the whole argument: every notch of recall is bought with
+    precision, and the price is paid by whoever the classifier is wrong about.</small>
+  </fieldset>
+
+  <div class="op-field" role="img" aria-label="A field of four hundred channels; hatched cells are coordinated farm clusters, dotted cells are human channels; dark cells have been swept; red cells are humans swept in error" id="op-fieldbox">
+    <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+    <div class="op-grid" id="op-grid"></div>
+    <div class="op-legend">
+      <span class="l-farm"><i></i>FARM CLUSTER</span>
+      <span class="l-human"><i></i>HUMAN CHANNEL</span>
+      <span class="l-swept"><i></i>SWEPT</span>
+      <span class="l-fp"><i></i>HUMAN, SWEPT IN ERROR</span>
+    </div>
+  </div>
+
+  <div class="op-probe">
+    <button id="op-run" type="button">Run the sweep</button>
+    <button id="op-reset" type="button" disabled>Restore the field</button>
+    <small>The desk's two controls. The classifier decides who goes; you only
+    choose how hungry it is — that is the argument.</small>
+  </div>
+
+  <section class="op-prose">
+    <p>The unit of moderation used to be the video. This year it became the
+    neighbourhood. A cluster-termination system does not ask whether a channel's
+    latest upload broke a rule; it asks who the channel resembles — who it shares a
+    template with, an upload cadence with, a server with — and when the resemblance
+    crosses a threshold, the whole block goes at once. Against content farms filing
+    synthetic videos at industrial scale, nothing else works. You cannot adjudicate
+    twenty million daily uploads one screen at a time.</p>
+    <p>But resemblance is a statistic, and a decade-old animation studio with
+    twenty-five million subscribers can resemble a farm on the day the threshold
+    moves. When it happened, the misread channel was not deleted — it was quietly
+    starved, its reach choked while its click-through rate and watch time said the
+    audience wanted more. It was repaired within days, because that channel had
+    people to call. The overturn rate stays under one percent partly because most of
+    the one percent never finds the phone.</p>
+  </section>
+
+  <section class="op-ledgerlist">
+    <h2>Session ledger · 台帳 — this desk only; unrecorded; reload erases it</h2>
+    <ul id="op-receipts"><li class="empty">No sweeps yet. The field stands as filed.</li></ul>
+  </section>
+</div>
+
+  <section class="op-reg">
+    <div class="op-frame">
+      <h2>The register · what is claimed on the public record</h2>
+      <p class="note">The field above is a simulation drawn in-house. These rows are
+      not — they are the claims this dispatch is filed against, printed with their
+      sources, as a magazine that names its sources must.</p>
+      <div class="wrap"><table class="op-rtable">
+        <thead><tr><th>CLAIM</th><th>AS REPORTED</th></tr></thead>
+        <tbody>
+          <tr><td>THE SYSTEM</td><td>A Google research paper describes a scalable cluster-termination
+            system (SCCTS) — an LLM-enabled multimodal defense — deployed to "a major online video
+            platform" against coordinated synthetic-media abuse.</td></tr>
+          <tr><td>THE SWEEP</td><td>Roughly 50,000 coordinated clusters identified; on the order of
+            130,000 channels terminated; independent reporting puts the purge above 100,000 channels
+            inside six months.</td></tr>
+          <tr><td>THE ERROR BAR</td><td>Appeal-overturn rate reported under one percent — hundreds of
+            legitimate channels terminated and later restored, in the paper's own sample.</td></tr>
+          <tr><td>THE SCALE</td><td>The platform stated in 2025 that at least 20 million videos are
+            uploaded per day. At that volume, a one-percent error rate is not a rounding error;
+            it is a population.</td></tr>
+          <tr><td>THE FALSE POSITIVE</td><td>Kurzgesagt — 25 million subscribers, over 3.5 billion
+            views, human-made for over a decade — publicly reported that the platform's automatic
+            AI-detection tools wrongly classified its videos as synthetic and throttled the channel;
+            platform contacts confirmed and repaired it.</td></tr>
+          <tr><td>THE ASYMMETRY</td><td>A five-million-subscriber creator reported months of decaying
+            reach with no way to learn whether a classifier was the cause — the appeal that repaired
+            the larger channel was a relationship, not a process.</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+  </section>
+
+<div class="op-frame">
+  <footer class="op-colophon">
+    <p>THE ONE PERCENT · 一パーセント · KERNEL PRESS <span class="op-glyph">★</span><br>
+    The field above is a simulation drawn in-house — no classifier was queried, no
+    request leaves this page. Its four hundred channels are deterministic from seed
+    <b>428-0805</b>, printed at the masthead; at rest the field always reads the same.
+    The sweep's hit rates are authored to illustrate the threshold trade, not measured
+    from the platform. The session ledger counts only this desk's sweeps and is erased
+    on reload; nothing is recorded. The register at the floor cites public reporting.
+    Under reduced motion every sweep resolves instantly. Print keeps the field and the
+    register and hides the controls.</p>
+  </footer>
+</div>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  var reduced=matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* deterministic PRNG — seed prints on the masthead */
+  function mulberry32(a){return function(){a|=0;a=a+0x6D2B79F5|0;var t=Math.imul(a^a>>>15,1|a);t=t+Math.imul(t^t>>>7,61|t)^t;return((t^t>>>14)>>>0)/4294967296}}
+  var SEED=4280805;
+
+  /* ---- the field: 400 channels, seeded. Farms arrive in clusters. ---- */
+  var N=400, COLS=20, cells=[], kinds=[];
+  (function(){
+    var r=mulberry32(SEED);
+    for(var i=0;i<N;i++)kinds.push('human');
+    /* plant 14 farm clusters as contiguous blocks on the grid */
+    for(var c=0;c<14;c++){
+      var cx=Math.floor(r()*COLS),cy=Math.floor(r()*(N/COLS)),size=8+Math.floor(r()*18);
+      var placed=0,radius=1;
+      while(placed<size&&radius<9){
+        for(var dy=-radius;dy<=radius&&placed<size;dy++)for(var dx=-radius;dx<=radius&&placed<size;dx++){
+          var x=cx+dx,y=cy+dy;
+          if(x<0||x>=COLS||y<0||y>=N/COLS)continue;
+          var idx=y*COLS+x;
+          if(kinds[idx]==='human'&&r()<.62){kinds[idx]='farm';placed++}
+        }
+        radius++;
+      }
+    }
+  })();
+
+  var grid=document.getElementById('op-grid');
+  for(var i=0;i<N;i++){
+    var d=document.createElement('div');d.className='op-ch';
+    d.dataset.kind=kinds[i];cells.push(d);grid.appendChild(d);
+  }
+
+  /* ---- threshold radiogroup (roving tabindex) ---- */
+  var thresh='standard';
+  var radios=[].slice.call(document.querySelectorAll('#op-thresh [role="radio"]'));
+  function pick(btn){
+    radios.forEach(function(b){var on=b===btn;b.setAttribute('aria-checked',on?'true':'false');b.tabIndex=on?0:-1});
+    thresh=btn.dataset.t;
+  }
+  radios.forEach(function(b,i){
+    b.addEventListener('click',function(){pick(b)});
+    b.addEventListener('keydown',function(e){
+      var j=-1;
+      if(e.key==='ArrowRight'||e.key==='ArrowDown')j=(i+1)%radios.length;
+      if(e.key==='ArrowLeft'||e.key==='ArrowUp')j=(i-1+radios.length)%radios.length;
+      if(j>=0){e.preventDefault();pick(radios[j]);radios[j].focus()}
+    });
+  });
+
+  /* authored hit rates — illustrative of the trade, disclosed in the colophon */
+  var RATES={
+    lenient:  {farm:.62, human:.002},
+    standard: {farm:.94, human:.010},
+    strict:   {farm:.995,human:.055}
+  };
+
+  var runs=0,runsEl=document.getElementById('op-runs'),
+      sweptEl=document.getElementById('op-swept'),fpEl=document.getElementById('op-fp'),
+      receipts=document.getElementById('op-receipts'),
+      runBtn=document.getElementById('op-run'),resetBtn=document.getElementById('op-reset');
+
+  function receipt(a,b){
+    var e=receipts.querySelector('.empty');if(e)e.remove();
+    var li=document.createElement('li');
+    li.innerHTML='<span></span><span></span>';
+    li.children[0].textContent=a;li.children[1].textContent=b;
+    receipts.appendChild(li);
+    while(receipts.children.length>7)receipts.removeChild(receipts.firstChild);
+  }
+
+  function restore(){
+    cells.forEach(function(c){delete c.dataset.state});
+    sweptEl.textContent='0';fpEl.textContent='0';
+    resetBtn.disabled=true;runBtn.disabled=false;
+  }
+  resetBtn.addEventListener('click',function(){restore();receipt('□ field restored','all fates cleared')});
+
+  runBtn.addEventListener('click',function(){
+    runs++;runsEl.textContent=runs;
+    var r=mulberry32(SEED+runs*97), rate=RATES[thresh];
+    var fates=[],swept=0,fp=0;
+    for(var i=0;i<N;i++){
+      var hit=r()<(kinds[i]==='farm'?rate.farm:rate.human);
+      fates.push(hit);
+      if(hit){swept++;if(kinds[i]==='human')fp++}
+    }
+    runBtn.disabled=true;resetBtn.disabled=true;
+    function apply(i){
+      if(fates[i])cells[i].dataset.state='swept';else delete cells[i].dataset.state;
+    }
+    function done(){
+      sweptEl.textContent=swept;fpEl.textContent=fp;
+      resetBtn.disabled=false;runBtn.disabled=false;
+      receipt('◆ '+thresh.toUpperCase()+' sweep',swept+' swept · '+fp+' human'+(fp===1?'':'s')+' in error');
+    }
+    if(reduced){for(var i=0;i<N;i++)apply(i);done();return}
+    /* timer-robust row-by-row sweep: rAF raced against a timer (house law) */
+    var row=0;
+    function step(){
+      for(var x=0;x<COLS;x++)apply(row*COLS+x);
+      row++;
+      if(row>=N/COLS){done();return}
+      var fired=false;
+      function go(){if(fired)return;fired=true;step()}
+      requestAnimationFrame(go);setTimeout(go,80);
+    }
+    step();
+  });
+})();
+</script>

--- a/src/content/issues/428.ts
+++ b/src/content/issues/428.ts
@@ -1,0 +1,209 @@
+/* ──────────────────────────────────────────────────────────────
+   ISSUE 428 — MAR 2027
+   THE ONE PERCENT
+   一パーセント — 検出器の誠実さは控訴窓口で測る
+
+   The wire story from the platform desk. A Google research paper
+   ("scalable detection of adversarial synthetic slop and
+   coordinated media abuse") describes a cluster-termination
+   system — SCCTS — deployed to a major online video platform:
+   channels judged by neighbourhood (shared behaviour, upload
+   rhythm, infrastructure), roughly 50,000 coordinated clusters
+   identified, on the order of 130,000 channels terminated, an
+   appeal-overturn rate under one percent. In the same season,
+   Kurzgesagt — 25 million subscribers, human-made for over a
+   decade — publicly reported that the platform’s automatic AI
+   detectors wrongly classified its videos as synthetic and
+   throttled the channel; its contacts at the platform confirmed
+   and repaired it within days. A five-million-subscriber
+   creator without those contacts reported months of decaying
+   reach with no way to learn the cause.
+
+   Filed as a dispatch because it happened on the record and
+   left a doctrine: a detector’s honesty is measured at its
+   appeal desk, not at its precision figure. Under one percent
+   of an industrial sweep is still a street of real people.
+
+   Identity decisions (differentiated from 401, the previous
+   dispatch — ivory / asymmetric-left / pool):
+     • coverStock = 'ledger' — the sweep IS an accounting
+       register; pale graph-ruled paper for a purge counted in
+       clusters and percentages.
+     • coverLayout = 'ledger-rule' — rules and numbered totals
+       across the cover; the cover is the audit (pairs with
+       ledger stock, per 372's precedent).
+     • coverSeal = TERMINATED · OVERTURNED — the whole story
+       in one rubber circle.
+     • accent = 'graphite' — pencil-lead grey for audits and
+       ledgers (introduced 372, paired with ledger stock). The
+       dispatch default (brick) belongs to news with blood in
+       it; this is news conducted in tabular numerals.
+     • spread.type = 'dispatch', spread.stock = 'ledger'.
+
+   Artifact edition drafted FIRST per artifact-language:
+   artifacts/428-the-one-percent.html — an operable sweep field
+   (400 seeded channels, farm clusters vs humans), a threshold
+   radiogroup carried into every sweep, honest authored hit
+   rates disclosed in the colophon, a claims register citing
+   public reporting at the floor, seed 428-0805 printed at the
+   masthead. The reduction to this spread gives up the operable
+   trade (threshold → false positives) and keeps its verdict as
+   prose in propositions 03 and 05.
+
+   Provenance: a reader-supplied transcript of a published
+   video commentary reporting the Google paper (credited there
+   to Jim Louderback’s newsletter), Kurzgesagt’s public
+   statement on its throttling, and the platform’s own 2025
+   statement of 20 million uploads per day. Claims are printed
+   as reported, with hedges kept.
+   ────────────────────────────────────────────────────────────── */
+
+import type { IssueRecord } from './index'
+
+export const ISSUE_428: IssueRecord = {
+  number: '428',
+  month: 'MAR',
+  year: '2027',
+  feature: 'THE ONE PERCENT',
+  featureJp: '一パーセント',
+  price: '¥0 · BYOK',
+  tagline: 'MAGAZINE FOR CITY CODERS · 街のコーダーのために',
+
+  coverStock: 'ledger',
+  coverLayout: 'ledger-rule',
+
+  coverSeal: {
+    label: 'TERMINATED · OVERTURNED',
+    date: 'III·27',
+  },
+
+  accent: 'graphite',
+
+  headline: {
+    prefix: 'The',
+    emphasis: 'One',
+    suffix: 'Percent.',
+    swash: 'A classifier learned to terminate channels by the neighbourhood and swept a hundred and thirty thousand of them. Its error bar is under one percent — and one percent of an industrial sweep is still a street of real people. A dispatch on the purge, the false positive with twenty-five million subscribers, and the appeal that turned out to be a phone number.',
+  },
+
+  contents: [
+    { n: '001', en: 'The sweep is real', jp: '一斉削除は本物である', tag: 'FIELD' },
+    { n: '002', en: 'Judgement moved to the neighbourhood', jp: '判定は近傍へ移った', tag: 'METHOD' },
+    { n: '003', en: 'The false positive wore a decade of humanity', jp: '誤検出は十年の人間性をまとう', tag: 'CAUTION' },
+    { n: '004', en: 'The appeal was a phone number', jp: '控訴は電話番号だった', tag: 'ACCESS' },
+    { n: '005', en: 'Measure the detector at its appeal desk', jp: '検出器は控訴窓口で測れ', tag: 'DOCTRINE' },
+  ],
+
+  spread: {
+    type: 'dispatch',
+    kicker: 'DISPATCH · 速報',
+    title: 'The One Percent.',
+    titleJp: '一パーセント。',
+    deck: 'The video platform’s war on synthetic slop found its weapon: terminate the cluster, not the video. Fifty thousand coordinated networks identified, a hundred and thirty thousand channels gone, and an appeal-overturn rate the research paper can print with pride — under one percent. Then the same family of detectors misread one of the most trusted human-made channels on the platform, throttled it quietly, and was corrected only because that channel had people to call. A dispatch on what the error bar hides.',
+    byline: 'BY THE EDITORS · KERNEL.CHAT',
+    stock: 'ledger',
+
+    slug: 'KERNEL.CHAT WIRE · 428 · III·27 · 50,000 CLUSTERS · 130,000 CHANNELS · OVERTURN UNDER 1% · INK STILL WET',
+
+    dateline: 'THE PLATFORM DESK — FILED WHILE THE SWEEP WAS STILL RUNNING.',
+
+    filedAt: '5 AUG 2026 · COVERING ONE SEASON',
+    status: 'FILED',
+
+    bridge: {
+      issue: '417',
+      text: '417 put a machine’s draft under a reader’s three fates — keep, take the hand, strike — one line at a time. 428 is the same adjudication running in reverse at industrial scale: a machine assigning fates to human work, with no radiogroup offered to the judged.',
+    },
+
+    intro: 'The research paper reads like plumbing and describes a purge. A cluster-termination system, deployed by its authors to "a major online video platform," stops asking whether a video broke a rule and starts asking who the channel resembles — who it shares a template with, an upload cadence with, a server with. When the resemblance crosses a threshold, the whole block goes at once. The numbers are the story: fifty thousand clusters, a hundred and thirty thousand channels, millions of videos, an overturn rate under one percent. This dispatch is filed for the remainder — the channels inside that one percent, and the difference between the two kinds of appeal available to them.',
+
+    propositions: [
+      {
+        n: '01',
+        overline: 'FIELD',
+        filedAt: '09:12',
+        title: 'The sweep is real.',
+        titleJp: '一斉削除は本物である',
+        body: [
+          'Over a hundred thousand channels removed inside six months, by public reporting — and the Google paper behind it claims roughly fifty thousand coordinated clusters identified and on the order of a hundred and thirty thousand channels terminated. The paper never names the platform; its authorship does that for it. These are not first-strike warnings. They are terminations, executed in groups.',
+          'The desk notes what the sweep is aimed at, because it matters for everything that follows: not the individual creator experimenting with a first faceless channel, but content farms filing synthetic video at industrial scale — connected operations sharing behaviour, upload patterns, and infrastructure. Against that adversary, the sweep is the right tool. The platform said in 2025 that at least twenty million videos arrive per day. Nothing adjudicated one screen at a time survives that arithmetic.',
+        ],
+      },
+      {
+        n: '02',
+        overline: 'METHOD',
+        filedAt: '10:04',
+        title: 'Judgement moved to the neighbourhood.',
+        titleJp: '判定は近傍へ移った',
+        body: [
+          'The quiet doctrine inside the paper is a change of unit. Moderation used to judge the video; then the channel; the cluster system judges the neighbourhood. A channel’s fate is decided partly by what it resembles — and resemblance is a statistic, computed over signals no creator can see, against a threshold no creator can read.',
+          'This is how every detection system scales, and the desk does not file it as scandal. It files it as a property with consequences: when the unit of judgement is the neighbourhood, the false positive is no longer a mislabelled video that can be re-reviewed. It is a livelihood, assigned to the wrong block by machinery that was never asked to explain itself.',
+        ],
+      },
+      {
+        n: '03',
+        overline: 'CAUTION',
+        filedAt: '11:40',
+        title: 'The false positive wore a decade of humanity.',
+        titleJp: '誤検出は十年の人間性をまとう',
+        body: [
+          'Kurzgesagt has spent over a decade making animation by hand — twenty-five million subscribers, more than three and a half billion views, and a body of work so canonical that it plausibly sits inside the training data of the very generators the platform is sweeping for. This year its views fell to levels it last saw in 2013, while click-through rate and watch time rose. The audience was leaning in; the distribution was gone.',
+          'The channel’s own account, published after it got answers: the platform’s automatic AI-detection tools wrongly classified its very much human-made videos as synthetic slop, and started to choke the channel. Not delete — choke. The misread was not a termination with a notice and an appeal link. It was a quiet starvation, invisible from the outside and nearly invisible from the inside, distinguishable from a change in taste only by a creator with the analytics fluency to prove the audience still wanted the work.',
+        ],
+      },
+      {
+        n: '04',
+        overline: 'ACCESS',
+        filedAt: '13:22',
+        title: 'The appeal was a phone number.',
+        titleJp: '控訴は電話番号だった',
+        body: [
+          'What repaired the misread was not the appeal process. It was contacts — the channel "quickly got in touch," the platform confirmed something was wrong, and the bug was, in the channel’s careful phrasing, hopefully fixed for now. The desk begrudges nobody here: the channel used the door it had, and the platform’s people were by all accounts helpful and transparent. That is the system working, for the channels it can see.',
+          'The filing is for the channels it cannot. A creator with five million subscribers reported the same shape of decay — months of worsening performance, no way to learn whether a classifier was the cause — and no phone to pick up. The overturn rate stays under one percent partly because overturning requires knowing you were misjudged, and the throttled are told nothing. An appeal that depends on a relationship is not a process. It is patronage with a ticketing system.',
+        ],
+      },
+      {
+        n: '05',
+        overline: 'DOCTRINE',
+        filedAt: '15:05',
+        title: 'Measure the detector at its appeal desk.',
+        titleJp: '検出器は控訴窓口で測れ',
+        body: [
+          'The doctrine that survives this filing is one sentence: a detection system’s honesty is measured at its appeal desk, not at its precision figure. Under one percent is a genuinely good number, and at twenty million uploads a day it is also thousands of misjudged people — a population, not a rounding error. The precision figure describes the sweep. Only the appeal desk describes what it is like to be swept.',
+          'The desk’s tests for any classifier holding livelihoods, filed for reuse: the misjudged must be told they were judged; the appeal must be a process that works without a relationship; and the throttle must be as visible as the termination — a channel choked in silence has been punished without ever being charged. The sweep against the farms can be a flower for the platform. The desk keeps one flower back until the one percent can find the door.',
+        ],
+      },
+    ],
+
+    bulletin: {
+      text: 'The classifier moved the unit of judgement from the video to the neighbourhood. The appeal never moved at all.',
+      attribution: 'KERNEL.CHAT · DISPATCH · 428',
+    },
+
+    outro: 'The farms will rebuild and the sweep will run again; that contest is permanent and the desk is glad the platform is finally winning rounds of it. The remainder is what this dispatch files for the record: a decade-old human channel misread by the machine, repaired through a door most creators will never have, and a percentage that reads as triumph in a research paper and as a season of silent starvation from inside the wrong block. File it beside 401’s doctrine — verify by event, not handshake. A platform that terminates by neighbourhood owes each neighbour, at minimum, the event: you were judged, here is the desk, the desk answers.',
+
+    signoff: '街のコーダーたちへ — count the swept, then count the misjudged; only one of those numbers is in the paper.',
+
+    terminator: 'END OF DISPATCH · KERNEL.CHAT/428 · FILED 5 AUG · ONE SEASON · INK STILL WET',
+  },
+
+  audit: {
+    drafted: 'artifact first · kernel.chat editorial · Claude Fable 5 · 5 August 2026',
+    verified:
+      'seven load-bearing claims — cluster count, channel count, overturn rate, upload volume, subscriber and view figures, the throttling account — each printed as reported with its source named in the register; hedges kept ("roughly", "on the order of", "hopefully fixed for now")',
+    adherence:
+      'ledger stock + ledger-rule + graphite per 372\'s audit-register precedent; sweep field deterministic from printed seed 428-0805; threshold radiogroup roving-tabindex; authored hit rates disclosed in the colophon; session ledger unrecorded and says so; reduced motion resolves sweeps instantly; print keeps the field and register, hides the controls',
+    readCut:
+      'source transcript ~1,900 words; kept the numbers, the Kurzgesagt account, and the access asymmetry; cut the presenter\'s stagecraft, the 3D-printed prop, and the self-referential shadowban test',
+    pressed: 'artifacts/428-the-one-percent.html · III·27',
+  },
+
+  credits: {
+    editorInChief: 'Isaac Hernandez',
+    creativeDirection: 'kernel.chat group',
+    artDirection: 'in-house',
+    copy: 'kernel.chat editorial',
+    japanese: 'kernel.chat editorial',
+    production: 'kernel.chat group',
+  },
+}

--- a/src/content/issues/PUBLISHING.md
+++ b/src/content/issues/PUBLISHING.md
@@ -208,7 +208,7 @@ register is expressed by SWITCHING the accent, not adding one.
 Create `src/content/issues/<N>.ts` following the shape of the most
 recent same-format issue (`371.ts` for essay-as-profile,
 `402.ts` for essay-as-argument (dossier + pull quote),
-`400.ts` for essay-with-dataBlock, `401.ts` for dispatch,
+`400.ts` for essay-with-dataBlock, `428.ts` for dispatch,
 `403.ts` for forecast, `427.ts` for interview (real named subject, quotes trimmed not invented — see also 365.ts for the composite-subject variant),
 `404.ts` for review (graded survey),
 `398.ts` for colloquy (two-voice),
@@ -503,7 +503,15 @@ branch — only main publishes.
 
 ---
 
-_Last updated: ISSUE 427 · FEB 2027 (THE MOAT IS REALITY — the
+_Last updated: ISSUE 428 · MAR 2027 (THE ONE PERCENT — a `dispatch`
+on the video platform's cluster-termination sweep (50,000 clusters,
+130,000 channels, overturn under 1%) and the Kurzgesagt false
+positive; ledger stock + ledger-rule + graphite per 372's
+audit-register precedent; artifact edition
+`artifacts/428-the-one-percent.html` drafted first — an operable
+sweep field with a threshold radiogroup, authored hit rates
+disclosed, and a claims register at the floor. Prior: 427 THE MOAT
+IS REALITY — the
 second `interview` instance, and the first with a real named subject
 (Alex Hormozi) rather than a composite. Nine exchanges trimmed, not
 invented, from a reader-supplied transcript of a real broadcast

--- a/src/content/issues/index.ts
+++ b/src/content/issues/index.ts
@@ -80,6 +80,7 @@ import { ISSUE_424 } from './424'
 import { ISSUE_425 } from './425'
 import { ISSUE_426 } from './426'
 import { ISSUE_427 } from './427'
+import { ISSUE_428 } from './428'
 
 // Re-export accent types so issue files can import from a single place.
 export type { IssueAccent, InkSeedName, InkSeed } from './accents'
@@ -163,6 +164,7 @@ export const ALL_ISSUES: IssueRecord[] = [
   ISSUE_425,
   ISSUE_426,
   ISSUE_427,
+  ISSUE_428,
 ]
 
 /** The latest published issue — drives the landing cover. */


### PR DESCRIPTION
## What

Ships ISSUE 428 — THE ONE PERCENT (一パーセント), a `dispatch` on the video platform's cluster-termination sweep against AI-slop content farms, and the false positive that hid inside its error bar. Adds the issue file, its mandatory artifact edition, registry wiring, and the PUBLISHING.md hygiene pass.

## Why

Filed from a reader-supplied transcript of a published video commentary: the Google SCCTS research paper (~50,000 coordinated clusters identified, on the order of 130,000 channels terminated, appeal-overturn rate under 1%), Kurzgesagt's public account of being misread as synthetic slop and throttled (25M subscribers, human-made for over a decade, repaired via direct platform contacts), and the access asymmetry for creators without those contacts. The doctrine the dispatch files: a detector's honesty is measured at its appeal desk, not its precision figure.

Fixes #

## How

- `src/content/issues/428.ts` — dispatch spread, five propositions (FIELD → METHOD → CAUTION → ACCESS → DOCTRINE), bridge to 417, wire bulletin, `— 30 —` terminator. Identity: `ledger` stock + `ledger-rule` layout + `graphite` accent per 372's audit-register precedent, differentiated from 401 (ivory/asymmetric-left/pool). Claims printed as reported, hedges kept; provenance filed in the header comment.
- `artifacts/428-the-one-percent.html` — artifact edition drafted first per artifact-language: an operable sweep field of 400 seeded channels (deterministic from printed seed 428-0805), a roving-tabindex threshold radiogroup carried into every sweep, authored hit rates disclosed in the colophon, a claims register citing public reporting at the floor, timer-robust sweep animation, reduced-motion instant resolution, print keeps the field/register and hides the controls. The reduction the spread gives up is filed in the issue header.
- `src/content/issues/index.ts` — import + `ALL_ISSUES` registration; `LATEST_ISSUE` flips to 428.
- `src/content/issues/PUBLISHING.md` — §IV dispatch example → 428, footer refreshed.
- `SCRATCHPAD.md` — session memory updated.

Nothing publishes from this branch; only main deploys.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (145 registry/accent tests)
- [x] `npx tsc --noEmit` passes (with the repo's local TypeScript 5.9.3; a globally-resolved 6.0.2 emits pre-existing tsconfig deprecation notices unrelated to this change)
- [ ] Tested manually with `kbot` in dev mode — n/a, magazine-only change

## Screenshots

n/a — preview locally with `npm run dev` at `/` (new cover) and `/issues/428`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcHbd4KB1YxK3HudJEsiuc

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcHbd4KB1YxK3HudJEsiuc)_