### PR TITLE
fix(security): revoke leaked Discord webhook, restore site monitoring

### DIFF
--- a/.github/workflows/cert-monitor.yml
+++ b/.github/workflows/cert-monitor.yml
@@ -1,16 +1,23 @@
 name: kernel.chat cert + site health monitor
 
-# Watches the GitHub Pages HTTPS certificate state and the live site,
-# alerts via Discord when:
-#   - Certificate state is not "approved"
-#   - Certificate expires within 14 days
-#   - Live site returns non-200 (anything other than a healthy response)
+# Watches the live kernel.chat TLS certificate and the site itself, alerting
+# via Discord when:
+#   - The served certificate expires within 14 days
+#   - The live site returns non-200 (anything other than a healthy response)
 #
-# Background: the cert expired on 2026-05-19 because Let's Encrypt
-# renewal had been silently failing (Cloudflare proxy intercepting the
-# ACME HTTP-01 challenge). Site went down with HTTP 526. This workflow
-# exists so the next time renewal starts failing we get a 30-day
-# warning instead of a same-day outage.
+# Background: the cert expired on 2026-05-19 because Let's Encrypt renewal had
+# been silently failing (Cloudflare proxy intercepting the ACME HTTP-01
+# challenge). Site went down with HTTP 526. This workflow exists so the next
+# time renewal starts failing we get a 14-day warning instead of a same-day
+# outage.
+#
+# 2026-08-13: this used to poll the GitHub Pages API for certificate state.
+# kernel.chat moved to Cloudflare Pages in July, so that API described a
+# certificate that no longer fronts the domain — and a naive/aware datetime
+# bug in the expiry math had been failing the job daily since 2026-07-07,
+# aborting the run under `set -e` BEFORE the live-site check ever ran. The
+# cert state now comes from the socket that actually serves users, which is
+# both correct today and survives the next migration.
 
 on:
   schedule:
@@ -26,41 +33,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check GitHub Pages cert state
+      - name: Check served TLS certificate
         id: cert
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          pages=$(gh api repos/${{ github.repository }}/pages)
-          echo "$pages" > /tmp/pages.json
 
-          state=$(echo "$pages" | python3 -c "import json,sys; d=json.load(sys.stdin); c=d.get('https_certificate') or {}; print(c.get('state', 'missing'))")
-          expires=$(echo "$pages" | python3 -c "import json,sys; d=json.load(sys.stdin); c=d.get('https_certificate') or {}; print(c.get('expires_at', '') or '')")
-          description=$(echo "$pages" | python3 -c "import json,sys; d=json.load(sys.stdin); c=d.get('https_certificate') or {}; print(c.get('description', '') or '')")
-          pages_status=$(echo "$pages" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status', 'missing'))")
+          # Read the certificate off the socket that actually serves the site,
+          # rather than asking any one hosting provider's API about it.
+          not_after=$(echo | openssl s_client -servername kernel.chat -connect kernel.chat:443 2>/dev/null \
+            | openssl x509 -noout -enddate \
+            | cut -d= -f2)
 
-          echo "state=$state" >> $GITHUB_OUTPUT
-          echo "expires=$expires" >> $GITHUB_OUTPUT
-          echo "description=$description" >> $GITHUB_OUTPUT
-          echo "pages_status=$pages_status" >> $GITHUB_OUTPUT
-
-          # Days-until-expiry math
-          if [ -n "$expires" ]; then
-            days_left=$(python3 -c "
-          from datetime import datetime, timezone
-          e = datetime.fromisoformat('$expires'.replace('Z','+00:00'))
-          now = datetime.now(timezone.utc)
-          print((e - now).days)
-          ")
-            echo "days_left=$days_left" >> $GITHUB_OUTPUT
-          else
+          if [ -z "$not_after" ]; then
+            echo "issuer=" >> $GITHUB_OUTPUT
+            echo "expires=" >> $GITHUB_OUTPUT
             echo "days_left=-999" >> $GITHUB_OUTPUT
+            echo "Could not read certificate from kernel.chat:443"
+            exit 0
           fi
 
-          echo "Cert state: $state"
-          echo "Cert expires: $expires"
-          echo "Pages status: $pages_status"
+          issuer=$(echo | openssl s_client -servername kernel.chat -connect kernel.chat:443 2>/dev/null \
+            | openssl x509 -noout -issuer \
+            | sed 's/^issuer=//')
+
+          # Both timestamps in epoch seconds — no timezone arithmetic to get wrong.
+          expiry_epoch=$(date -u -d "$not_after" +%s)
+          now_epoch=$(date -u +%s)
+          days_left=$(( (expiry_epoch - now_epoch) / 86400 ))
+
+          echo "issuer=$issuer" >> $GITHUB_OUTPUT
+          echo "expires=$not_after" >> $GITHUB_OUTPUT
+          echo "days_left=$days_left" >> $GITHUB_OUTPUT
+
+          echo "Cert issuer: $issuer"
+          echo "Cert expires: $not_after"
+          echo "Days to expiry: $days_left"
 
       - name: Check live site
         id: live
@@ -81,15 +88,12 @@ jobs:
           alert=false
           reason=""
 
-          # Cert in bad state
-          if [ "${{ steps.cert.outputs.state }}" != "approved" ]; then
-            alert=true
-            reason="Cert state is '${{ steps.cert.outputs.state }}' (expected 'approved'). ${{ steps.cert.outputs.description }}"
-          fi
-
-          # Cert expiring soon
+          # Certificate unreadable — the handshake itself failed.
           days_left=${{ steps.cert.outputs.days_left }}
-          if [ "$days_left" -lt 14 ] && [ "$days_left" -gt -900 ]; then
+          if [ "$days_left" -le -900 ]; then
+            alert=true
+            reason="Could not read a TLS certificate from kernel.chat:443."
+          elif [ "$days_left" -lt 14 ]; then
             alert=true
             reason="Cert expires in $days_left days (${{ steps.cert.outputs.expires }})."
           fi
@@ -114,16 +118,15 @@ jobs:
           fi
           curl -sS -H "Content-Type: application/json" -X POST "$WEBHOOK_URL" -d "{
             \"embeds\": [{
-              \"title\": \"⚠️ kernel.chat cert/site health alert\",
+              \"title\": \"kernel.chat cert/site health alert\",
               \"description\": \"${{ steps.decide.outputs.reason }}\",
               \"color\": 15548997,
               \"fields\": [
-                {\"name\": \"Cert state\", \"value\": \"${{ steps.cert.outputs.state }}\", \"inline\": true},
                 {\"name\": \"Days to expiry\", \"value\": \"${{ steps.cert.outputs.days_left }}\", \"inline\": true},
                 {\"name\": \"Live site HTTP\", \"value\": \"${{ steps.live.outputs.http_status }}\", \"inline\": true},
-                {\"name\": \"Pages status\", \"value\": \"${{ steps.cert.outputs.pages_status }}\", \"inline\": true},
                 {\"name\": \"Cert expires at\", \"value\": \"${{ steps.cert.outputs.expires }}\", \"inline\": true},
-                {\"name\": \"Action\", \"value\": \"Check Cloudflare proxy + GitHub Pages settings\", \"inline\": false}
+                {\"name\": \"Cert issuer\", \"value\": \"${{ steps.cert.outputs.issuer }}\", \"inline\": false},
+                {\"name\": \"Action\", \"value\": \"Check Cloudflare SSL/TLS settings + Pages deployment\", \"inline\": false}
               ],
               \"footer\": {\"text\": \"kernel.chat cert monitor · daily @ 14:00 UTC\"}
             }]
@@ -135,10 +138,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| Cert state | ${{ steps.cert.outputs.state }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cert issuer | ${{ steps.cert.outputs.issuer }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Cert expires | ${{ steps.cert.outputs.expires }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Days to expiry | ${{ steps.cert.outputs.days_left }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pages status | ${{ steps.cert.outputs.pages_status }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Live site HTTP | ${{ steps.live.outputs.http_status }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Alert raised | ${{ steps.decide.outputs.alert }} |" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.decide.outputs.alert }}" = "true" ]; then

--- a/tools/kbot-discovery-daemon.ts
+++ b/tools/kbot-discovery-daemon.ts
@@ -1960,7 +1960,11 @@ main().catch(err => {
 // === NOTIFICATION HOOK (added by Claude session 2026-03-25) ===
 // When synthesis finds actionable insights, notify Isaac via Discord webhook
 async function notifyFinding(finding: string): Promise<void> {
-  const webhook = process.env.DISCORD_WEBHOOK_URL || 'https://discord.com/api/webhooks/1482971938333655090/J6wozdd9BP19iWve3lak3kI8xxWhO073-WG48McaT1yq541tl9awSL4xvyykvY1eGV9m'
+  const webhook = process.env.DISCORD_WEBHOOK_URL
+  if (!webhook) {
+    log('DISCORD_WEBHOOK_URL not set; skipping notification.')
+    return
+  }
   try {
     await fetch(webhook, {
       method: 'POST',


### PR DESCRIPTION
Two findings from an external scan of this public repo on 2026-08-13, one credential and one silent monitoring outage. Both verified independently before acting; neither was taken on the scanner's word.

## 1. Leaked Discord webhook (revoked)

`tools/kbot-discovery-daemon.ts` carried a full Discord webhook URL as the fallback for `DISCORD_WEBHOOK_URL`. Introduced 2026-03-24 in 91bc26b4e, so it sat in a public repo for **142 days**. A GET against it immediately before revocation returned **HTTP 200** — a live webhook, not a stale token, meaning anyone who read the repo could post to the channel as the bot.

Revoked via the Discord API (`DELETE` -> 204; a follow-up GET now returns 404 Unknown Webhook), confirmed absent from the server's webhook list in the UI, and replaced with a new webhook whose URL exists only in `.env`.

The fallback is now a no-op plus a log line rather than a throw, matching `.claude/rules/backend.md` ("never let MCP servers crash") and the function's own don't-crash-the-daemon contract. A misconfigured daemon becomes visible in the log instead of silently posting to a secret nobody knew existed.

A repo-wide sweep for the same shape (`env || literal`, both `||` and `??`, Node and Deno) turned up 70 candidates, none secret-bearing; a second pass for hardcoded credential prefixes (`sk-`, `ghp_`, `xox*`, `AKIA`, `AIza`, JWTs, Slack/Discord webhook URLs) hit only deliberate test fixtures. This was the only instance.

## 2. Cert monitor had been failing daily for 37 days

The workflow polled the GitHub Pages API and did expiry math with `datetime.fromisoformat()` against an aware `now()`, raising `can't subtract offset-naive and offset-aware datetimes`. Under `set -e`, with the cert step running first, that aborted the job **before the live-site curl ever ran**. Since 2026-07-07 there has been no site monitoring at all, while the daily red X trained us to read the notification as routine noise.

Fixing the math alone would not have been enough. kernel.chat moved to Cloudflare Pages in July — the served certificate is issued by Google Trust Services (CN=WE1), so the GitHub Pages certificate the job asked about no longer fronts the domain. Cert state now comes from the socket that actually serves users (`openssl s_client`), which is correct today and survives the next migration, and expiry is epoch subtraction so there is no timezone arithmetic left to get wrong.

Verified against the live host: `notAfter=Oct 19 01:21:02 2026 GMT`, 67 days out, comfortably past the 14-day alert threshold.

## Related

Closed #69 (the report of finding 1, accurate) and #71 (an unsolicited vendor PR adding a third-party scanner action to CI, declined — its remaining claims are unverified and were not acted on).

## Follow-up not in this PR

`DISCORD_WEBHOOK_URL` must be set in `.env` and the discovery daemon restarted; until then notifications no-op with the new log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)